### PR TITLE
Allow whitelisted addresses to "proxy stake"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = 3
 name = "amm_pair"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-schema",
+ "cosmwasm-schema 1.0.0",
  "cosmwasm-std",
  "cosmwasm-storage",
  "schemars 0.8.10",
@@ -81,7 +81,7 @@ version = "0.1.0"
 source = "git+https://github.com/securesecrets/better-secret-math#78e1a9b770626e2b4df036ba17803a22c9427d63"
 dependencies = [
  "btr-macros",
- "cosmwasm-schema",
+ "cosmwasm-schema 1.1.1",
  "cosmwasm-std",
  "derive-from-ext",
  "ethnum",
@@ -202,14 +202,36 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.1"
-source = "git+https://github.com/CosmWasm/cosmwasm#c3b02c8b63bc2e8daae1bca539717dc0a41a7d2d"
+version = "1.0.0"
+source = "git+https://github.com/CosmWasm/cosmwasm?rev=1e05e7e#1e05e7eeac406b4e9f15e0700f8997a7baf0c7f6"
 dependencies = [
- "cosmwasm-schema-derive",
+ "cosmwasm-schema-derive 1.0.0",
  "schemars 0.8.10",
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-schema"
+version = "1.1.1"
+source = "git+https://github.com/CosmWasm/cosmwasm#c3b02c8b63bc2e8daae1bca539717dc0a41a7d2d"
+dependencies = [
+ "cosmwasm-schema-derive 1.1.1",
+ "schemars 0.8.10",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-schema-derive"
+version = "1.0.0"
+source = "git+https://github.com/CosmWasm/cosmwasm?rev=1e05e7e#1e05e7eeac406b4e9f15e0700f8997a7baf0c7f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -415,7 +437,7 @@ dependencies = [
 name = "factory"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-schema",
+ "cosmwasm-schema 1.0.0",
  "cosmwasm-std",
  "cosmwasm-storage",
  "schemars 0.8.10",
@@ -581,7 +603,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.12.3",
  "bincode2",
- "cosmwasm-schema",
+ "cosmwasm-schema 1.0.0",
  "cosmwasm-std",
  "cosmwasm-storage",
  "rand_chacha 0.2.2",
@@ -715,7 +737,7 @@ version = "0.1.0"
 source = "git+https://github.com/securesecrets/query-authentication?branch=cosmwasm_v1_upgrade#e2ead5e85dc2ac4f77b2cbf86a90d166bdbb5950"
 dependencies = [
  "bech32",
- "cosmwasm-schema",
+ "cosmwasm-schema 1.1.1",
  "cosmwasm-std",
  "remain",
  "ripemd160",
@@ -821,7 +843,7 @@ dependencies = [
 name = "router"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-schema",
+ "cosmwasm-schema 1.0.0",
  "cosmwasm-std",
  "cosmwasm-storage",
  "schemars 0.8.10",
@@ -1162,7 +1184,7 @@ name = "shadeswap-shared"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "cosmwasm-schema",
+ "cosmwasm-schema 1.0.0",
  "cosmwasm-std",
  "cosmwasm-storage",
  "query-authentication",
@@ -1236,7 +1258,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.12.3",
  "bincode2",
- "cosmwasm-schema",
+ "cosmwasm-schema 1.0.0",
  "cosmwasm-std",
  "cosmwasm-storage",
  "rand_chacha 0.2.2",
@@ -1263,7 +1285,7 @@ dependencies = [
 name = "staking"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-schema",
+ "cosmwasm-schema 1.0.0",
  "cosmwasm-std",
  "cosmwasm-storage",
  "query-authentication",

--- a/contracts/amm_pair/Cargo.toml
+++ b/contracts/amm_pair/Cargo.toml
@@ -15,17 +15,6 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-codegen-units = 1
-debug = true
-debug-assertions = true
-incremental = true
-lto = true
-opt-level = 3
-overflow-checks = true
-panic = 'abort'
-rpath = true
-
 [features]
 default = []
 # for quicker tests, cargo test --lib
@@ -44,4 +33,4 @@ snafu = {version = "0.7.1"}
 secret-multi-test = { git = "https://github.com/securesecrets/secret-plus-utils", version = "0.13.4" }
 
 [dev-dependencies]
-cosmwasm-schema = {git = "https://github.com/CosmWasm/cosmwasm", commit = "1e05e7e"}
+cosmwasm-schema = {git = "https://github.com/CosmWasm/cosmwasm", rev = "1e05e7e"}

--- a/contracts/amm_pair/src/operations.rs
+++ b/contracts/amm_pair/src/operations.rs
@@ -43,7 +43,7 @@ use crate::{
 
 // WHITELIST
 pub fn add_whitelist_address(storage: &mut dyn Storage, address: Addr) -> StdResult<()> {
-    let mut unwrap_data = match whitelist_r(storage).may_load(){
+    let mut unwrap_data = match whitelist_r(storage).may_load() {
         Ok(v) => v.unwrap_or(Vec::new()),
         Err(err) => Vec::new(),
     };
@@ -509,7 +509,7 @@ pub fn calculate_swap_result(
     let mut lp_fee_amount = Uint128::zero();
     let mut shade_dao_fee_amount = Uint128::zero();
     // calculation fee
-    let discount_fee =  is_address_in_whitelist(deps.storage, recipient)?;
+    let discount_fee = is_address_in_whitelist(deps.storage, recipient)?;
     if discount_fee == false {
         match &config.custom_fee {
             Some(f) => {
@@ -555,7 +555,7 @@ pub fn add_address_to_whitelist(
     add_whitelist_address(storage, address.clone())?;
     Ok(Response::default().add_attributes(vec![
         Attribute::new("action", "save_address_to_whitelist"),
-        Attribute::new("whitelist_address", address.as_str().clone()),
+        Attribute::new("whitelist_address", address),
     ]))
 }
 
@@ -564,7 +564,7 @@ pub fn remove_address_from_whitelist(
     list: Vec<Addr>,
     env: Env,
 ) -> StdResult<Response> {
-    remove_whitelist_address(storage, list.clone())?;
+    remove_whitelist_address(storage, list)?;
     Ok(Response::default().add_attribute("action", "remove_address_from_whitelist"))
 }
 

--- a/contracts/amm_pair/src/test.rs
+++ b/contracts/amm_pair/src/test.rs
@@ -1,100 +1,119 @@
-use shadeswap_shared::amm_pair::{{AMMPair, AMMSettings}};
-use shadeswap_shared::msg::amm_pair::{{ TradeHistory}};
-use cosmwasm_std::{QuerierResult, Querier, QueryRequest};
-use shadeswap_shared::{
-        contract_interfaces::snip20::{InstantiateMsg},
-        core::{
-            admin_r, admin_w, apply_admin_guard, create_viewing_key, set_admin_guard, ContractLink,
-            TokenAmount, TokenType,
-        },
-        msg::amm_pair::{ExecuteMsg, InitMsg, InvokeMsg, QueryMsg,SwapInfo, SwapResult, QueryMsgResponse},
-        msg::staking::InitMsg as StakingInitMsg,
-        Contract,
-    };
-    use shadeswap_shared::contract_interfaces::snip20::InitConfig;
-use std::hash::Hash;
-use crate::state::{{Config}};    
+use crate::state::Config;
+use cosmwasm_std::testing::{mock_env, mock_info, MOCK_CONTRACT_ADDR};
+use cosmwasm_std::{Querier, QuerierResult, QueryRequest};
 use serde::Deserialize;
 use serde::Serialize;
-use cosmwasm_std::testing::{mock_env, mock_info,MOCK_CONTRACT_ADDR};
+use shadeswap_shared::amm_pair::{AMMPair, AMMSettings};
+use shadeswap_shared::contract_interfaces::snip20::InitConfig;
+use shadeswap_shared::msg::amm_pair::TradeHistory;
+use shadeswap_shared::{
+    contract_interfaces::snip20::InstantiateMsg,
+    core::{
+        admin_r, admin_w, apply_admin_guard, create_viewing_key, set_admin_guard, ContractLink,
+        TokenAmount, TokenType,
+    },
+    msg::amm_pair::{
+        ExecuteMsg, InitMsg, InvokeMsg, QueryMsg, QueryMsgResponse, SwapInfo, SwapResult,
+    },
+    msg::staking::InitMsg as StakingInitMsg,
+    Contract,
+};
+use std::hash::Hash;
 pub const FACTORY_CONTRACT_ADDRESS: &str = "FACTORY_CONTRACT_ADDRESS";
 pub const CUSTOM_TOKEN_1: &str = "CUSTOM_TOKEN_1";
 pub const CUSTOM_TOKEN_2: &str = "CUSTOM_TOKEN_2";
 pub const CONTRACT_ADDRESS: &str = "CONTRACT_ADDRESS";
 pub const LP_TOKEN_ADDRESS: &str = "LP_TOKEN_ADDRESS";
 use crate::help_math::calculate_and_print_price;
+use crate::state::config_r;
 use cosmwasm_std::{
     entry_point, from_binary, to_binary, Addr, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
     Reply, Response, StdError, StdResult, SubMsg, SubMsgResult, Uint128, WasmMsg,
 };
 use shadeswap_shared::core::{Callback, ContractInstantiationInfo};
-use crate::state::config_r;
 
 #[cfg(test)]
 pub mod tests {
+    use super::help_test_lib::{make_init_config, mk_amm_settings, mk_token_pair};
     use super::*;
-    use super::help_test_lib::{mk_token_pair, mk_amm_settings, make_init_config};   
-    use cosmwasm_std::{Coin, OwnedDeps, Empty, from_slice, SystemResult, SystemError, BlockInfo, Timestamp, ContractInfo, TransactionInfo, BalanceResponse};
-    use cosmwasm_std::testing::{MockStorage, MockApi, MockQuerierCustomHandlerResult, BankQuerier};
-    use serde::de::DeserializeOwned;   
-    use shadeswap_shared::core::{Fee, TokenPair};
-    use shadeswap_shared::msg::factory::{QueryResponse as FactoryQueryResponse,QueryMsg as FactoryQueryMsg };
-    use shadeswap_shared::snip20::QueryAnswer;
-    use shadeswap_shared::snip20::manager::Balance;   
     use crate::contract::{instantiate, query};
-    use crate::operations::{swap, add_whitelist_address, is_address_in_whitelist, add_address_to_whitelist, calculate_hash};
+    use crate::operations::{
+        add_address_to_whitelist, add_whitelist_address, calculate_hash, is_address_in_whitelist,
+        swap,
+    };
     use crate::state::{config_w, trade_count_r};
-    use crate::test::help_test_lib::{mock_dependencies, mk_custom_token_amount, mk_native_token_pair, mock_custom_env};
-   
+    use crate::test::help_test_lib::{
+        mk_custom_token_amount, mk_native_token_pair, mock_custom_env, mock_dependencies,
+    };
+    use cosmwasm_std::testing::{
+        BankQuerier, MockApi, MockQuerierCustomHandlerResult, MockStorage,
+    };
+    use cosmwasm_std::{
+        from_slice, BalanceResponse, BlockInfo, Coin, ContractInfo, Empty, OwnedDeps, SystemError,
+        SystemResult, Timestamp, TransactionInfo,
+    };
+    use serde::de::DeserializeOwned;
+    use shadeswap_shared::core::{Fee, TokenPair};
+    use shadeswap_shared::msg::factory::{
+        QueryMsg as FactoryQueryMsg, QueryResponse as FactoryQueryResponse,
+    };
+    use shadeswap_shared::snip20::manager::Balance;
+    use shadeswap_shared::snip20::QueryAnswer;
 
     #[test]
-    fn assert_init_config() -> StdResult<()> {       
+    fn assert_init_config() -> StdResult<()> {
         let seed = to_binary(&"SEED".to_string())?;
         let entropy = to_binary(&"ENTROPY".to_string())?;
         let mut deps = mock_dependencies(&[]);
         let mut env = mock_env();
-        let mock_info = mock_info("test",&[]);
+        let mock_info = mock_info("test", &[]);
         env.block.height = 200_000;
         env.contract.address = Addr::unchecked("ContractAddress".to_string());
         let token_pair = mk_token_pair();
         let msg = InitMsg {
             pair: token_pair,
-            lp_token_contract: ContractInstantiationInfo{
-                  code_hash: "CODE_HASH".to_string(),
-                  id :0
+            lp_token_contract: ContractInstantiationInfo {
+                code_hash: "CODE_HASH".to_string(),
+                id: 0,
             },
             factory_info: ContractLink {
                 address: Addr::unchecked("FACTORYADDR"),
-                code_hash: "FACTORYADDR_HASH".to_string()
+                code_hash: "FACTORYADDR_HASH".to_string(),
             },
             prng_seed: seed.clone(),
             entropy: entropy.clone(),
-            admin: Some(mock_info.sender.clone()),           
+            admin: Some(mock_info.sender.clone()),
             staking_contract: None,
             custom_fee: None,
             callback: None,
-        };     
-        assert!(instantiate(deps.as_mut(), env.clone(),mock_info.clone(), msg).is_ok());     
-        let test_view_key = create_viewing_key(&env, &mock_info.clone(), seed.clone(),entropy.clone());
+        };
+        assert!(instantiate(deps.as_mut(), env.clone(), mock_info.clone(), msg).is_ok());
+        let test_view_key =
+            create_viewing_key(&env, &mock_info.clone(), seed.clone(), entropy.clone());
         // load config
         let config = config_r(deps.as_mut().storage).load()?;
-        let contract_add_token_0 = match(config.pair.0) {
-            TokenType::CustomToken { contract_addr, token_code_hash } => contract_addr.to_string(),
-            TokenType::NativeToken { denom } => "".to_string()
+        let contract_add_token_0 = match (config.pair.0) {
+            TokenType::CustomToken {
+                contract_addr,
+                token_code_hash,
+            } => contract_addr.to_string(),
+            TokenType::NativeToken { denom } => "".to_string(),
         };
         assert_eq!(contract_add_token_0, CUSTOM_TOKEN_1);
-        let contract_add_token_1 = match(config.pair.1) {
-            TokenType::CustomToken { contract_addr, token_code_hash } => contract_addr.to_string(),
-            TokenType::NativeToken { denom } => "".to_string()
+        let contract_add_token_1 = match (config.pair.1) {
+            TokenType::CustomToken {
+                contract_addr,
+                token_code_hash,
+            } => contract_addr.to_string(),
+            TokenType::NativeToken { denom } => "".to_string(),
         };
         assert_eq!(contract_add_token_1, CUSTOM_TOKEN_2);
         assert_eq!(test_view_key, config.viewing_key);
         Ok(())
     }
 
- 
     #[test]
-    fn assert_load_trade_history_first_time() -> StdResult<()>{
+    fn assert_load_trade_history_first_time() -> StdResult<()> {
         let deps = mock_dependencies(&[]);
         let initial_value = match trade_count_r(&deps.storage).load() {
             Ok(it) => it,
@@ -103,107 +122,121 @@ pub mod tests {
         assert_eq!(0, initial_value);
         Ok(())
     }
-   
+
     #[test]
-    fn assert_add_address_to_whitelist_success()-> StdResult<()>{
+    fn assert_add_address_to_whitelist_success() -> StdResult<()> {
         let seed = to_binary(&"SEED".to_string())?;
         let entropy = to_binary(&"ENTROPY".to_string())?;
         let mut deps = mock_dependencies(&[]);
         let mut env = mock_env();
-        let mock_info = mock_info("test",&[]);
+        let mock_info = mock_info("test", &[]);
         env.block.height = 200_000;
         env.contract.address = Addr::unchecked("ContractAddress".to_string());
         let token_pair = mk_token_pair();
         let msg = InitMsg {
             pair: token_pair,
-            lp_token_contract: ContractInstantiationInfo{
-                  code_hash: "CODE_HASH".to_string(),
-                  id :0
+            lp_token_contract: ContractInstantiationInfo {
+                code_hash: "CODE_HASH".to_string(),
+                id: 0,
             },
             factory_info: ContractLink {
                 address: Addr::unchecked("FACTORYADDR"),
-                code_hash: "FACTORYADDR_HASH".to_string()
+                code_hash: "FACTORYADDR_HASH".to_string(),
             },
             prng_seed: seed.clone(),
             entropy: entropy.clone(),
-            admin: Some(mock_info.sender.clone()),           
+            admin: Some(mock_info.sender.clone()),
             staking_contract: None,
             custom_fee: None,
             callback: None,
-        };     
-        assert!(instantiate(deps.as_mut(), env.clone(),mock_info.clone(), msg).is_ok());         
-        let address_a =  Addr::unchecked("TESTA".to_string());
-        let address_b =  Addr::unchecked("TESTB".to_string());
-        let response = add_address_to_whitelist(deps.as_mut().storage, address_a.clone(), env.clone())?;        
+        };
+        assert!(instantiate(deps.as_mut(), env.clone(), mock_info.clone(), msg).is_ok());
+        let address_a = Addr::unchecked("TESTA".to_string());
+        let address_b = Addr::unchecked("TESTB".to_string());
+        let response =
+            add_address_to_whitelist(deps.as_mut().storage, address_a.clone(), env.clone())?;
         let is_stalker_a = is_address_in_whitelist(deps.as_mut().storage, address_a.clone())?;
-        assert_eq!(true, is_stalker_a);        
+        assert_eq!(true, is_stalker_a);
         add_address_to_whitelist(deps.as_mut().storage, address_b.clone(), env.clone())?;
         let is_stalker_b = is_address_in_whitelist(deps.as_mut().storage, address_b.clone())?;
-        assert_eq!(true, is_stalker_b);     
+        assert_eq!(true, is_stalker_b);
         Ok(())
     }
 
     //#[test]
-    fn assert_remove_address_from_whitelist_success()-> StdResult<()>{
+    fn assert_remove_address_from_whitelist_success() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
-        let env = mock_env();       
-        let address_a =  Addr::unchecked("TESTA".to_string());
-        let address_b =  Addr::unchecked("TESTB".to_string());
-        let address_c =  Addr::unchecked("TESTC".to_string());
-        add_whitelist_address(deps.as_mut().storage, address_a.clone())?;                    
+        let env = mock_env();
+        let address_a = Addr::unchecked("TESTA".to_string());
+        let address_b = Addr::unchecked("TESTB".to_string());
+        let address_c = Addr::unchecked("TESTC".to_string());
+        add_whitelist_address(deps.as_mut().storage, address_a.clone())?;
         add_whitelist_address(deps.as_mut().storage, address_b.clone())?;
         Ok(())
     }
 
-    
     #[test]
-    fn assert_load_address_from_whitelist_success()-> StdResult<()>{
+    fn assert_load_address_from_whitelist_success() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
-        let env = mock_env();       
+        let env = mock_env();
         let address_a = Addr::unchecked("TESTA".to_string());
-        let address_b =  Addr::unchecked("TESTB".to_string());
-        let address_c =  Addr::unchecked("TESTC".to_string());
+        let address_b = Addr::unchecked("TESTB".to_string());
+        let address_c = Addr::unchecked("TESTC".to_string());
         add_whitelist_address(&mut deps.storage, address_a.clone())?;
         add_whitelist_address(&mut deps.storage, address_b.clone())?;
         add_whitelist_address(&mut deps.storage, address_c.clone())?;
-        let is_addr = is_address_in_whitelist(&mut deps.storage, address_b.clone())?;  
-        assert_eq!(true, is_addr);      
-        let is_addr = is_address_in_whitelist(&mut deps.storage, Addr::unchecked("TESTD".to_string()).clone())?;  
-        assert_eq!(false, is_addr);   
+        let is_addr = is_address_in_whitelist(&mut deps.storage, address_b.clone())?;
+        assert_eq!(true, is_addr);
+        let is_addr = is_address_in_whitelist(
+            &mut deps.storage,
+            Addr::unchecked("TESTD".to_string()).clone(),
+        )?;
+        assert_eq!(false, is_addr);
         Ok(())
     }
 
     #[test]
-    fn assert_swap_native_snip20()-> StdResult<()>{
+    fn assert_swap_native_snip20() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
-        let env = mock_custom_env(FACTORY_CONTRACT_ADDRESS);        
+        let env = mock_custom_env(FACTORY_CONTRACT_ADDRESS);
         let token_pair = mk_native_token_pair();
-        let config = make_init_config(mk_native_token_pair().clone())?;       
-        let address_a = Addr::unchecked("TESTA".to_string());      
-        assert_eq!(config.factory_contract.address.as_str(), FACTORY_CONTRACT_ADDRESS.clone());
-        let router_contract = ContractLink{
+        let config = make_init_config(mk_native_token_pair().clone())?;
+        let address_a = Addr::unchecked("TESTA".to_string());
+        assert_eq!(
+            config.factory_contract.address.as_str(),
+            FACTORY_CONTRACT_ADDRESS
+        );
+        let router_contract = ContractLink {
             address: Addr::unchecked("router".to_string()),
-            code_hash: "".to_string()
+            code_hash: "".to_string(),
         };
         let signature = to_binary(&"signature".to_string())?;
-        let native_swap = swap(deps.as_mut(), env, config, address_a.clone(), 
-            None,  mk_custom_token_amount(Uint128::from(1000u128), token_pair.clone()),None, 
-            Some(router_contract), Some(signature))?; 
-        let offer_amount = &native_swap.clone().attributes[2];          
+        let native_swap = swap(
+            deps.as_mut(),
+            env,
+            config,
+            address_a.clone(),
+            None,
+            mk_custom_token_amount(Uint128::from(1000u128), token_pair.clone()),
+            None,
+            Some(router_contract),
+            Some(signature),
+        )?;
+        let offer_amount = &native_swap.clone().attributes[2];
         assert_eq!(offer_amount.value, 65420.to_string());
         assert_eq!(native_swap.messages.len(), 3);
         Ok(())
     }
 
     #[test]
-    fn assert_query_get_amm_pairs_success()-> StdResult<()>{
+    fn assert_query_get_amm_pairs_success() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
         let env = mock_env();
         let amm_settings = mk_amm_settings();
         let token_pair = mk_token_pair();
-        let config = make_init_config(token_pair)?;         
+        let config = make_init_config(token_pair)?;
         let offer_amount: u128 = 34028236692093846346337460;
-        let expected_amount: u128 = 34028236692093846346337460;           
+        let expected_amount: u128 = 34028236692093846346337460;
         let address_a = "TESTA".to_string();
         // handle(
         //     &mut deps,
@@ -231,10 +264,10 @@ pub mod tests {
         //     _ => panic!("QueryResponse::ListExchanges"),
         // }
         Ok(())
-    }    
+    }
 
     #[test]
-    pub fn assert_trader_address_hash() -> StdResult<()>{
+    pub fn assert_trader_address_hash() -> StdResult<()> {
         let trader = Addr::unchecked("test");
         let hash_address = calculate_hash(&trader.to_string());
         assert_eq!("14402189752926126668", hash_address.to_string());
@@ -242,125 +275,199 @@ pub mod tests {
     }
 }
 
-
 #[cfg(test)]
-pub mod tests_calculation_price_and_fee{    
+pub mod tests_calculation_price_and_fee {
+    use super::help_test_lib::{make_init_config, mk_amm_settings, mk_token_pair};
     use super::*;
-    use super::help_test_lib::{mk_token_pair, mk_amm_settings, make_init_config};   
-    use cosmwasm_std::{Coin, OwnedDeps, Empty, from_slice, SystemResult, SystemError, BlockInfo, Timestamp, ContractInfo, TransactionInfo, BalanceResponse, Decimal};
-    use cosmwasm_std::testing::{MockStorage, MockApi, MockQuerierCustomHandlerResult, BankQuerier};
-    use serde::de::DeserializeOwned;   
-    use shadeswap_shared::core::{Fee, TokenPair, CustomFee, TokenPairAmount};
-    use shadeswap_shared::msg::factory::{QueryResponse as FactoryQueryResponse,QueryMsg as FactoryQueryMsg };
-    use shadeswap_shared::router;
-    use shadeswap_shared::snip20::QueryAnswer;
-    use shadeswap_shared::snip20::manager::Balance;   
     use crate::contract::{instantiate, query};
-    use crate::operations::{swap, add_whitelist_address, is_address_in_whitelist, add_address_to_whitelist, calculate_price, calculate_swap_result, add_liquidity};
+    use crate::operations::{
+        add_address_to_whitelist, add_liquidity, add_whitelist_address, calculate_price,
+        calculate_swap_result, is_address_in_whitelist, swap,
+    };
     use crate::state::{config_w, trade_count_r};
-    use crate::test::help_test_lib::{mock_dependencies, mk_custom_token_amount, mk_native_token_pair, mock_custom_env, make_init_config_test_calculate_price_fee, mk_token_pair_test_calculation_price_fee, mk_custom_token_amount_test_calculation_price_fee, mk_amm_settings_a, mk_native_token_pair_test_calculation_price_fee};
+    use crate::test::help_test_lib::{
+        make_init_config_test_calculate_price_fee, mk_amm_settings_a, mk_custom_token_amount,
+        mk_custom_token_amount_test_calculation_price_fee, mk_native_token_pair,
+        mk_native_token_pair_test_calculation_price_fee, mk_token_pair_test_calculation_price_fee,
+        mock_custom_env, mock_dependencies,
+    };
+    use cosmwasm_std::testing::{
+        BankQuerier, MockApi, MockQuerierCustomHandlerResult, MockStorage,
+    };
+    use cosmwasm_std::{
+        from_slice, BalanceResponse, BlockInfo, Coin, ContractInfo, Decimal, Empty, OwnedDeps,
+        SystemError, SystemResult, Timestamp, TransactionInfo,
+    };
+    use serde::de::DeserializeOwned;
+    use shadeswap_shared::core::{CustomFee, Fee, TokenPair, TokenPairAmount};
+    use shadeswap_shared::msg::factory::{
+        QueryMsg as FactoryQueryMsg, QueryResponse as FactoryQueryResponse,
+    };
+    use shadeswap_shared::router;
+    use shadeswap_shared::snip20::manager::Balance;
+    use shadeswap_shared::snip20::QueryAnswer;
 
-     #[test]
-    fn assert_calculate_and_print_price() -> StdResult<()>{
-        let result_a = calculate_and_print_price(Uint128::from(99u128), Uint128::from(100u128),0)?;
-        let result_b = calculate_and_print_price(Uint128::from(58u128), Uint128::from(124u128),1)?;
-        let result_c = calculate_and_print_price(Uint128::from(158u128), Uint128::from(124u128),0)?;
+    #[test]
+    fn assert_calculate_and_print_price() -> StdResult<()> {
+        let result_a = calculate_and_print_price(Uint128::from(99u128), Uint128::from(100u128), 0)?;
+        let result_b = calculate_and_print_price(Uint128::from(58u128), Uint128::from(124u128), 1)?;
+        let result_c =
+            calculate_and_print_price(Uint128::from(158u128), Uint128::from(124u128), 0)?;
         assert_eq!(result_a, "0.99".to_string());
         assert_eq!(result_b, "0.467741935483870967".to_string());
         assert_eq!(result_c, "1.274193548387096774".to_string());
         Ok(())
     }
 
-     #[test]
-    fn assert_calculate_price() -> StdResult<()>{     
-        let price = calculate_price(Uint128::from(2000u128), Uint128::from(10000u128), Uint128::from(100000u128));
+    #[test]
+    fn assert_calculate_price() -> StdResult<()> {
+        let price = calculate_price(
+            Uint128::from(2000u128),
+            Uint128::from(10000u128),
+            Uint128::from(100000u128),
+        );
         assert_eq!(Uint128::from(16666u128), price?);
         Ok(())
     }
 
     #[test]
-    fn assert_calculate_price_sell() -> StdResult<()>{     
-        let price = calculate_price(Uint128::from(2000u128), Uint128::from(100000u128), Uint128::from(10000u128));
+    fn assert_calculate_price_sell() -> StdResult<()> {
+        let price = calculate_price(
+            Uint128::from(2000u128),
+            Uint128::from(100000u128),
+            Uint128::from(10000u128),
+        );
         assert_eq!(Uint128::from(196u128), price?);
         Ok(())
     }
-        
+
     #[test]
-    fn assert_initial_swap_with_token_success_without_fee() -> StdResult<()>
-    {     
+    fn assert_initial_swap_with_token_success_without_fee() -> StdResult<()> {
         let custom_fee: Option<CustomFee> = None;
         let mut deps = mock_dependencies(&[]);
         let amm_settings = mk_amm_settings_a();
         let env = mock_custom_env(FACTORY_CONTRACT_ADDRESS);
         let token_pair = mk_token_pair_test_calculation_price_fee();
-        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, custom_fee)?;           
+        let config =
+            make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, custom_fee)?;
         let offer_amount: u128 = 2000;
         let expected_amount: u128 = 1666;
-        let swap_result = calculate_swap_result(deps.as_mut().as_ref(),&env, &amm_settings, &config,
-            &mk_custom_token_amount_test_calculation_price_fee(Uint128::from(offer_amount), config.pair.clone()), 
-            Addr::unchecked("Test".to_string().clone()), Some(true));
-        assert_eq!(Uint128::from(expected_amount), swap_result?.result.return_amount);
+        let swap_result = calculate_swap_result(
+            deps.as_mut().as_ref(),
+            &env,
+            &amm_settings,
+            &config,
+            &mk_custom_token_amount_test_calculation_price_fee(
+                Uint128::from(offer_amount),
+                config.pair.clone(),
+            ),
+            Addr::unchecked("Test".to_string().clone()),
+            Some(true),
+        );
+        assert_eq!(
+            Uint128::from(expected_amount),
+            swap_result?.result.return_amount
+        );
         Ok(())
     }
 
     #[test]
-    fn assert_initial_swap_with_token_success_with_fee() -> StdResult<()>
-    {     
+    fn assert_initial_swap_with_token_success_with_fee() -> StdResult<()> {
         let custom_fee: Option<CustomFee> = None;
         let mut deps = mock_dependencies(&[]);
         let amm_settings = mk_amm_settings_a();
         let env = mock_env();
         let token_pair = mk_token_pair_test_calculation_price_fee();
-        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, custom_fee)?;           
+        let config =
+            make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, custom_fee)?;
         let offer_amount: u128 = 2000;
         let expected_amount: u128 = 1624;
-        let swap_result = calculate_swap_result(deps.as_mut().as_ref(),&env, &amm_settings, &config,
-            &mk_custom_token_amount_test_calculation_price_fee(Uint128::from(offer_amount), config.pair.clone()), 
-             Addr::unchecked("Test".to_string().clone()), None);
-        assert_eq!(Uint128::from(expected_amount), swap_result?.result.return_amount);
+        let swap_result = calculate_swap_result(
+            deps.as_mut().as_ref(),
+            &env,
+            &amm_settings,
+            &config,
+            &mk_custom_token_amount_test_calculation_price_fee(
+                Uint128::from(offer_amount),
+                config.pair.clone(),
+            ),
+            Addr::unchecked("Test".to_string().clone()),
+            None,
+        );
+        assert_eq!(
+            Uint128::from(expected_amount),
+            swap_result?.result.return_amount
+        );
         Ok(())
     }
 
     #[test]
-    fn assert_swap_with_custom_fee_success() -> StdResult<()>{
-        let custom_fee = Some( CustomFee{
+    fn assert_swap_with_custom_fee_success() -> StdResult<()> {
+        let custom_fee = Some(CustomFee {
             shade_dao_fee: Fee { nom: 8, denom: 100 },
-            lp_fee: Fee { nom: 1, denom: 100},
+            lp_fee: Fee { nom: 1, denom: 100 },
         });
         let mut deps = mock_dependencies(&[]);
         let amm_settings = mk_amm_settings_a();
         let token_pair = mk_token_pair_test_calculation_price_fee();
-        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, custom_fee)?;           
+        let config =
+            make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, custom_fee)?;
         let offer_amount: u128 = 2000;
         let env = mock_env();
         let expected_amount: u128 = 1539;
-        let swap_result = calculate_swap_result(deps.as_mut().as_ref(), &env, &amm_settings, &config, 
-            &mk_custom_token_amount_test_calculation_price_fee(Uint128::from(offer_amount), config.pair.clone()), 
-         Addr::unchecked("Test".to_string().clone()), None);
-        assert_eq!(Uint128::from(expected_amount), swap_result?.result.return_amount);
+        let swap_result = calculate_swap_result(
+            deps.as_mut().as_ref(),
+            &env,
+            &amm_settings,
+            &config,
+            &mk_custom_token_amount_test_calculation_price_fee(
+                Uint128::from(offer_amount),
+                config.pair.clone(),
+            ),
+            Addr::unchecked("Test".to_string().clone()),
+            None,
+        );
+        assert_eq!(
+            Uint128::from(expected_amount),
+            swap_result?.result.return_amount
+        );
         Ok(())
     }
-        
+
     #[test]
-    fn assert_calculate_swap_result_without_custom_fee() -> StdResult<()>{
+    fn assert_calculate_swap_result_without_custom_fee() -> StdResult<()> {
         let custom_fee: Option<CustomFee> = None;
         let mut deps = mock_dependencies(&[]);
         let token_pair = mk_native_token_pair_test_calculation_price_fee();
-        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair.clone(), None)?;       
+        let config =
+            make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair.clone(), None)?;
         let address_a = Addr::unchecked("TESTA".to_string());
-        let token_amount = mk_custom_token_amount_test_calculation_price_fee(Uint128::from(2000u128), config.pair.clone());   
+        let token_amount = mk_custom_token_amount_test_calculation_price_fee(
+            Uint128::from(2000u128),
+            config.pair.clone(),
+        );
         let amm_settings = shadeswap_shared::amm_pair::AMMSettings {
             lp_fee: Fee::new(2, 100),
             shade_dao_fee: Fee::new(3, 100),
             shade_dao_address: ContractLink {
                 address: Addr::unchecked("DAO"),
                 code_hash: "".to_string(),
-            }
+            },
         };
         let env = mock_custom_env(FACTORY_CONTRACT_ADDRESS);
-        assert_eq!(config.factory_contract.address.as_str(), FACTORY_CONTRACT_ADDRESS.clone());
-        let swap_result = calculate_swap_result(deps.as_mut().as_ref(),&env, &amm_settings, &config, &token_amount,
-         address_a, None)?;
+        assert_eq!(
+            config.factory_contract.address.as_str(),
+            FACTORY_CONTRACT_ADDRESS
+        );
+        let swap_result = calculate_swap_result(
+            deps.as_mut().as_ref(),
+            &env,
+            &amm_settings,
+            &config,
+            &token_amount,
+            address_a,
+            None,
+        )?;
         assert_eq!(swap_result.result.return_amount, Uint128::from(159663u128));
         assert_eq!(swap_result.lp_fee_amount, Uint128::from(40u128));
         assert_eq!(swap_result.shade_dao_fee_amount, Uint128::from(60u128));
@@ -368,313 +475,329 @@ pub mod tests_calculation_price_and_fee{
         Ok(())
     }
 
-        #[test]
-    fn assert_initial_swap_with_zero_fee_for_whitelist_address()-> StdResult<()>{
+    #[test]
+    fn assert_initial_swap_with_zero_fee_for_whitelist_address() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
         let amm_settings = mk_amm_settings_a();
         let token_pair = mk_token_pair_test_calculation_price_fee();
-        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, None)?;         
+        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, None)?;
         let offer_amount: u128 = 2000;
         let env = mock_custom_env(FACTORY_CONTRACT_ADDRESS);
-        let expected_amount: u128 = 1666;           
+        let expected_amount: u128 = 1666;
         let address_a = Addr::unchecked("TESTA".to_string());
-        add_whitelist_address(deps.as_mut().storage, address_a.clone())?;    
-        let swap_result = calculate_swap_result(deps.as_mut().as_ref(), &env,&amm_settings, &config,
-            &mk_custom_token_amount_test_calculation_price_fee(Uint128::from(offer_amount), config.pair.clone()), 
-            address_a.clone(), None)?;
-        assert_eq!(Uint128::from(expected_amount), swap_result.result.return_amount);
+        add_whitelist_address(deps.as_mut().storage, address_a.clone())?;
+        let swap_result = calculate_swap_result(
+            deps.as_mut().as_ref(),
+            &env,
+            &amm_settings,
+            &config,
+            &mk_custom_token_amount_test_calculation_price_fee(
+                Uint128::from(offer_amount),
+                config.pair.clone(),
+            ),
+            address_a.clone(),
+            None,
+        )?;
+        assert_eq!(
+            Uint128::from(expected_amount),
+            swap_result.result.return_amount
+        );
         assert_eq!(Uint128::zero(), swap_result.lp_fee_amount);
         Ok(())
     }
 
-    
     #[test]
-    fn assert_slippage_swap_result_with_less_return_amount_throw_exception() -> StdResult<()>{
+    fn assert_slippage_swap_result_with_less_return_amount_throw_exception() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
         let amm_settings = mk_amm_settings_a();
         let token_pair = mk_token_pair_test_calculation_price_fee();
-        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, None)?;         
+        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, None)?;
         let offer_amount: u128 = 2000;
-        let expected_amount: u128 = 16666;           
+        let expected_amount: u128 = 16666;
         let address_a = Addr::unchecked("TESTA".to_string());
-        let token = config.pair.clone();        
+        let token = config.pair.clone();
         let swap_and_test_slippage = swap(
             deps.as_mut(),
             mock_custom_env(FACTORY_CONTRACT_ADDRESS),
             config,
             address_a.clone(),
-            Some(address_a.clone()),          
-            mk_custom_token_amount_test_calculation_price_fee(Uint128::from(offer_amount), token), 
+            Some(address_a.clone()),
+            mk_custom_token_amount_test_calculation_price_fee(Uint128::from(offer_amount), token),
             Some(Uint128::from(40000u128)),
-            None, 
-            None
+            None,
+            None,
         );
 
         match swap_and_test_slippage.unwrap_err() {
-            e =>  assert_eq!(e, StdError::generic_err(
-                "Operation fell short of expected_return",
-            )),
-        }       
+            e => assert_eq!(
+                e,
+                StdError::generic_err("Operation fell short of expected_return",)
+            ),
+        }
         Ok(())
     }
 
-        #[test]
-    fn assert_slippage_swap_result_with_higher_return_amount_success() -> StdResult<()>{
+    #[test]
+    fn assert_slippage_swap_result_with_higher_return_amount_success() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
         let amm_settings = mk_amm_settings_a();
         let token_pair = mk_token_pair_test_calculation_price_fee();
-        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, None)?;         
-        let offer_amount: u128 = 2000;          
+        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair, None)?;
+        let offer_amount: u128 = 2000;
         let address_a = "TESTA".to_string();
-        let token = config.pair.clone();  
-        let router_contract = ContractLink{
+        let token = config.pair.clone();
+        let router_contract = ContractLink {
             address: Addr::unchecked("".to_string()),
-            code_hash: "".to_string()
-        }; 
+            code_hash: "".to_string(),
+        };
         let signature = to_binary(&"signature".to_string())?;
         let swap_and_test_slippage = swap(
             deps.as_mut(),
             mock_custom_env(FACTORY_CONTRACT_ADDRESS),
             config,
             Addr::unchecked(address_a.clone()),
-            Some(Addr::unchecked(address_a.clone())),          
-            mk_custom_token_amount_test_calculation_price_fee(Uint128::from(offer_amount), token), 
+            Some(Addr::unchecked(address_a.clone())),
+            mk_custom_token_amount_test_calculation_price_fee(Uint128::from(offer_amount), token),
             Some(Uint128::from(400u128)),
-            Some(router_contract), 
-            Some(signature)
+            Some(router_contract),
+            Some(signature),
         );
-         assert_eq!(
-            swap_and_test_slippage.unwrap().attributes[2].value, 
-            1228.to_string());
-        Ok(())
-    }
-
-        #[test]
-    fn assert_slippage_add_liqudity_with_wrong_ration_throw_error() -> StdResult<()>{
-        let mut deps = mock_dependencies(&[]);
-        let amm_settings = mk_amm_settings_a();
-        let token_pair = mk_token_pair_test_calculation_price_fee();
-        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair.clone(), None)?;         
-        let offer_amount: u128 = 2000;          
-        let mock_info = mock_info("Sender", &[]);
-        let address_a = Addr::unchecked("TESTA".to_string());
-        let token = config.pair.clone();  
-        let add_liquidity_with_err = add_liquidity(
-            deps.as_mut(),
-            mock_env(),
-            &mock_info,
-            TokenPairAmount{
-                pair: token_pair.clone(),
-                amount_0: Uint128::from(1000000u128),
-                amount_1: Uint128::from(10000u128)
-            },
-            Some(Decimal::percent(20)),
-            None
-        );       
-
-        match add_liquidity_with_err {  
-            Ok(_) => todo!(),
-            Err(e) => assert_eq!(e, StdError::generic_err(
-                "Operation exceeds max slippage acceptance",
-            )),
-        }       
+        assert_eq!(
+            swap_and_test_slippage.unwrap().attributes[2].value,
+            1228.to_string()
+        );
         Ok(())
     }
 
     #[test]
-    fn assert_slippage_add_liqudity_with_right_ration_success() -> StdResult<()>{
+    fn assert_slippage_add_liqudity_with_wrong_ration_throw_error() -> StdResult<()> {
+        let mut deps = mock_dependencies(&[]);
+        let amm_settings = mk_amm_settings_a();
+        let token_pair = mk_token_pair_test_calculation_price_fee();
+        let config =
+            make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair.clone(), None)?;
+        let offer_amount: u128 = 2000;
+        let mock_info = mock_info("Sender", &[]);
+        let address_a = Addr::unchecked("TESTA".to_string());
+        let token = config.pair.clone();
+        let add_liquidity_with_err = add_liquidity(
+            deps.as_mut(),
+            mock_env(),
+            &mock_info,
+            TokenPairAmount {
+                pair: token_pair.clone(),
+                amount_0: Uint128::from(1000000u128),
+                amount_1: Uint128::from(10000u128),
+            },
+            Some(Decimal::percent(20)),
+            None,
+        );
+
+        match add_liquidity_with_err {
+            Ok(_) => todo!(),
+            Err(e) => assert_eq!(
+                e,
+                StdError::generic_err("Operation exceeds max slippage acceptance",)
+            ),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn assert_slippage_add_liqudity_with_right_ration_success() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
         let amm_settings = mk_amm_settings_a();
         let token_pair = mk_token_pair_test_calculation_price_fee();
         let env = mock_env();
         let mock_info = mock_info("Sender", &[]);
-        let config = make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair.clone(), None)?;        
-        let offer_amount: u128 = 2000;          
+        let config =
+            make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair.clone(), None)?;
+        let offer_amount: u128 = 2000;
         let address_a = "TESTA".to_string();
-        let token = config.pair.clone();  
+        let token = config.pair.clone();
         let add_liquidity_with_err = add_liquidity(
             deps.as_mut(),
             env.clone(),
             &mock_info,
-            TokenPairAmount{
+            TokenPairAmount {
                 pair: token_pair.clone(),
                 amount_0: Uint128::from(10000u128),
-                amount_1: Uint128::from(100000u128)
+                amount_1: Uint128::from(100000u128),
             },
             Some(Decimal::percent(20)),
-            None
-        );       
+            None,
+        );
 
-        match add_liquidity_with_err {  
+        match add_liquidity_with_err {
             Ok(_) => todo!(),
-            Err(e) => assert_eq!(e, StdError::generic_err(
-                "Operation exceeds max slippage acceptance",
-            )),
-        }       
+            Err(e) => assert_eq!(
+                e,
+                StdError::generic_err("Operation exceeds max slippage acceptance",)
+            ),
+        }
         Ok(())
     }
 }
 
-
 pub mod help_test_lib {
-    use super::*;   
-    use cosmwasm_std::{Coin, OwnedDeps, Empty, from_slice, SystemResult, SystemError, BlockInfo, Timestamp, ContractInfo, TransactionInfo, BalanceResponse};
-    use cosmwasm_std::testing::{MockStorage, MockApi, MockQuerierCustomHandlerResult, BankQuerier};
-    use serde::de::DeserializeOwned;   
-    use shadeswap_shared::core::{Fee, TokenPair, CustomFee};
-    use shadeswap_shared::msg::factory::{QueryResponse as FactoryQueryResponse,QueryMsg as FactoryQueryMsg };
-    use shadeswap_shared::snip20::QueryAnswer;
-    use shadeswap_shared::snip20::manager::Balance;
-    use shadeswap_shared::stake_contract::StakingContractInit;   
+    use super::*;
     use crate::contract::{instantiate, query};
-    use crate::operations::{swap, add_whitelist_address, is_address_in_whitelist, add_address_to_whitelist};
+    use crate::operations::{
+        add_address_to_whitelist, add_whitelist_address, is_address_in_whitelist, swap,
+    };
     use crate::state::{config_w, trade_count_r};
-       
-    pub fn make_init_config(   
-        token_pair: TokenPair) -> StdResult<Config> {    
+    use cosmwasm_std::testing::{
+        BankQuerier, MockApi, MockQuerierCustomHandlerResult, MockStorage,
+    };
+    use cosmwasm_std::{
+        from_slice, BalanceResponse, BlockInfo, Coin, ContractInfo, Empty, OwnedDeps, SystemError,
+        SystemResult, Timestamp, TransactionInfo,
+    };
+    use serde::de::DeserializeOwned;
+    use shadeswap_shared::core::{CustomFee, Fee, TokenPair};
+    use shadeswap_shared::msg::factory::{
+        QueryMsg as FactoryQueryMsg, QueryResponse as FactoryQueryResponse,
+    };
+    use shadeswap_shared::snip20::manager::Balance;
+    use shadeswap_shared::snip20::QueryAnswer;
+    use shadeswap_shared::stake_contract::StakingContractInit;
+
+    pub fn make_init_config(token_pair: TokenPair) -> StdResult<Config> {
         let mut deps = mock_dependencies(&[]);
         let seed = to_binary(&"SEED".to_string())?;
         let entropy = to_binary(&"ENTROPY".to_string())?;
-        let env = mock_env();  
-        let mock_info = mock_info(MOCK_CONTRACT_ADDR,&[]);
+        let env = mock_env();
+        let mock_info = mock_info(MOCK_CONTRACT_ADDR, &[]);
         let msg = InitMsg {
             pair: token_pair.clone(),
-            lp_token_contract: ContractInstantiationInfo{
+            lp_token_contract: ContractInstantiationInfo {
                 code_hash: "CODE_HASH".to_string(),
-                id :0
+                id: 0,
             },
             factory_info: ContractLink {
                 address: Addr::unchecked(FACTORY_CONTRACT_ADDRESS),
-                code_hash: "".to_string()
+                code_hash: "".to_string(),
             },
             prng_seed: seed.clone(),
             entropy: entropy.clone(),
-            admin: Some(mock_info.sender.clone()),      
+            admin: Some(mock_info.sender.clone()),
             staking_contract: None,
             custom_fee: None,
             callback: None,
-        };         
+        };
         assert!(instantiate(deps.as_mut(), env.clone(), mock_info.clone(), msg).is_ok());
         let config = config_r(&deps.storage).load()?;
-        Ok(config)       
+        Ok(config)
     }
 
-    pub fn mk_amm_settings_a() -> AMMSettings{
-        AMMSettings{
-            lp_fee: Fee{
-                nom: 2,
-                denom: 100
-            },
-            shade_dao_fee: Fee {
-                nom: 1,
-                denom: 100
-            },
-            shade_dao_address: ContractLink{
+    pub fn mk_amm_settings_a() -> AMMSettings {
+        AMMSettings {
+            lp_fee: Fee { nom: 2, denom: 100 },
+            shade_dao_fee: Fee { nom: 1, denom: 100 },
+            shade_dao_address: ContractLink {
                 code_hash: "CODEHAS".to_string(),
-                address: Addr::unchecked("TEST".to_string())
-            }
+                address: Addr::unchecked("TEST".to_string()),
+            },
         }
     }
 
-    pub fn mk_token_pair() -> TokenPair{
-        let pair =  TokenPair(
+    pub fn mk_token_pair() -> TokenPair {
+        let pair = TokenPair(
             TokenType::CustomToken {
                 contract_addr: Addr::unchecked(CUSTOM_TOKEN_1.to_string().clone()),
-                token_code_hash: CUSTOM_TOKEN_1.to_string()
-            },            
+                token_code_hash: CUSTOM_TOKEN_1.to_string(),
+            },
             TokenType::CustomToken {
                 contract_addr: Addr::unchecked(CUSTOM_TOKEN_2.to_string().clone()),
-                token_code_hash: CUSTOM_TOKEN_2.to_string()
-            }
+                token_code_hash: CUSTOM_TOKEN_2.to_string(),
+            },
         );
         pair
     }
 
-    pub fn mk_native_token_pair() -> TokenPair{
-        let pair =  TokenPair(
+    pub fn mk_native_token_pair() -> TokenPair {
+        let pair = TokenPair(
             TokenType::CustomToken {
                 contract_addr: Addr::unchecked(CUSTOM_TOKEN_2.to_string()),
-                token_code_hash: CUSTOM_TOKEN_2.to_string()
-            },            
+                token_code_hash: CUSTOM_TOKEN_2.to_string(),
+            },
             TokenType::NativeToken {
-                denom: "uscrt".into()
-            }
+                denom: "uscrt".into(),
+            },
         );
         pair
     }
 
-
-    pub fn mk_custom_token_amount(amount: Uint128, token_pair: TokenPair) -> TokenAmount{    
-        let token = TokenAmount{
+    pub fn mk_custom_token_amount(amount: Uint128, token_pair: TokenPair) -> TokenAmount {
+        let token = TokenAmount {
             token: token_pair.0.clone(),
             amount: amount.clone(),
         };
         token
     }
 
-    pub fn mk_custom_token(address: String) -> TokenType{
+    pub fn mk_custom_token(address: String) -> TokenType {
         TokenType::CustomToken {
             contract_addr: Addr::unchecked(address.clone()),
-            token_code_hash: "TOKEN0_HASH".to_string()
+            token_code_hash: "TOKEN0_HASH".to_string(),
         }
     }
 
-    pub fn mk_native_token() -> TokenType{
-        TokenType::NativeToken{
-            denom: "uscrt".to_string()
+    pub fn mk_native_token() -> TokenType {
+        TokenType::NativeToken {
+            denom: "uscrt".to_string(),
         }
     }
 
-    pub fn mk_amm_settings() -> AMMSettings{
-        AMMSettings{
-            shade_dao_fee: Fee {
-                nom: 1,
-                denom: 100
-            },
-            lp_fee: Fee{
-                nom: 2,
-                denom: 100
-            },
-            shade_dao_address: ContractLink{
+    pub fn mk_amm_settings() -> AMMSettings {
+        AMMSettings {
+            shade_dao_fee: Fee { nom: 1, denom: 100 },
+            lp_fee: Fee { nom: 2, denom: 100 },
+            shade_dao_address: ContractLink {
                 code_hash: "CODEHAS".to_string(),
-                address: Addr::unchecked("TEST".to_string())
-            }
+                address: Addr::unchecked("TEST".to_string()),
+            },
         }
     }
 
-    pub fn mock_config(env: Env) -> StdResult<Config>
-    {    
+    pub fn mock_config(env: Env) -> StdResult<Config> {
         let seed = to_binary(&"SEED".to_string())?;
         let entropy = to_binary(&"ENTROPY".to_string())?;
         let mk_info = mock_info("sender", &[]);
 
-        Ok(Config {       
+        Ok(Config {
             factory_contract: mock_contract_link(FACTORY_CONTRACT_ADDRESS.to_string()),
             lp_token: mock_contract_link("LPTOKEN".to_string()),
             staking_contract: Some(mock_contract_link(MOCK_CONTRACT_ADDR.to_string())),
-            pair:      mk_token_pair(),
-            viewing_key:  create_viewing_key(&env, &mk_info.clone(), seed.clone(), entropy.clone()),
+            pair: mk_token_pair(),
+            viewing_key: create_viewing_key(&env, &mk_info.clone(), seed.clone(), entropy.clone()),
             custom_fee: None,
-            staking_contract_init: Some(StakingContractInit{ 
-                contract_info: ContractInstantiationInfo { code_hash:"".to_string(), id: 1 }, 
-                amount: Uint128::from(1000u128), 
-                reward_token: TokenType::CustomToken { contract_addr: Addr::unchecked("".to_string()), token_code_hash: "".to_string() },
+            staking_contract_init: Some(StakingContractInit {
+                contract_info: ContractInstantiationInfo {
+                    code_hash: "".to_string(),
+                    id: 1,
+                },
+                amount: Uint128::from(1000u128),
+                reward_token: TokenType::CustomToken {
+                    contract_addr: Addr::unchecked("".to_string()),
+                    token_code_hash: "".to_string(),
+                },
             }),
             prng_seed: to_binary(&"to_string".to_string())?,
         })
     }
 
-    pub fn mock_contract_link(address: String)-> ContractLink{
-        ContractLink{
+    pub fn mock_contract_link(address: String) -> ContractLink {
+        ContractLink {
             address: Addr::unchecked(address.clone()),
-            code_hash: "CODEHASH".to_string()
+            code_hash: "CODEHASH".to_string(),
         }
     }
 
-    pub fn mock_contract_info(address: &str) -> ContractLink{
-        ContractLink{
-            address :Addr::unchecked(address.clone()),
-            code_hash: "".to_string()
+    pub fn mock_contract_info(address: &str) -> ContractLink {
+        ContractLink {
+            address: Addr::unchecked(address.clone()),
+            code_hash: "".to_string(),
         }
     }
 
@@ -695,26 +818,26 @@ pub mod help_test_lib {
 
     pub fn mock_dependencies(
         contract_balance: &[Coin],
-      ) -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
+    ) -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
         let contract_addr = Addr::unchecked(MOCK_CONTRACT_ADDR);
         OwnedDeps {
-          storage: MockStorage::default(),
-          api: MockApi::default(),
-          querier: MockQuerier{portion :100},
-            custom_query_type: std::marker::PhantomData,      
+            storage: MockStorage::default(),
+            api: MockApi::default(),
+            querier: MockQuerier { portion: 100 },
+            custom_query_type: std::marker::PhantomData,
         }
-      }
+    }
 
     #[derive(Serialize, Deserialize)]
     struct IntBalanceResponse {
         pub balance: Balance,
     }
-    
-    pub struct MockQuerier{
+
+    pub struct MockQuerier {
         portion: u128,
     }
     impl Querier for MockQuerier {
-        fn raw_query (&self, bin_request: &[u8]) -> QuerierResult {
+        fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
             let request: QueryRequest<Empty> = from_slice(bin_request).unwrap();
             match &request {
                 QueryRequest::Bank(msg) => {
@@ -722,151 +845,164 @@ pub mod help_test_lib {
                         cosmwasm_std::BankQuery::Balance { address, denom } => {
                             match address.as_str() {
                                 CUSTOM_TOKEN_2 => {
-                                    let balance = to_binary(&QueryAnswer::Balance { amount: Uint128::from(1000u128)}).unwrap();
+                                    let balance = to_binary(&QueryAnswer::Balance {
+                                        amount: Uint128::from(1000u128),
+                                    })
+                                    .unwrap();
                                     QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
-                                },
+                                }
                                 FACTORY_CONTRACT_ADDRESS => {
-                                    let balance = to_binary(&BalanceResponse{
-                                        amount: Coin{
+                                    let balance = to_binary(&BalanceResponse {
+                                        amount: Coin {
                                             denom: "uscrt".into(),
                                             amount: Uint128::from(1000000u128),
-                                        }
-                                    }).unwrap();
+                                        },
+                                    })
+                                    .unwrap();
                                     // let balance = to_binary(&QueryAnswer::Balance { amount: Uint128::from(1000u128)}).unwrap();
                                     QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
-                                },
+                                }
                                 CUSTOM_TOKEN_1 => {
-                                    let balance = to_binary(&BalanceResponse{
-                                        amount: Coin{
+                                    let balance = to_binary(&BalanceResponse {
+                                        amount: Coin {
                                             denom: "uscrt".into(),
                                             amount: Uint128::from(1000000u128),
-                                        }
-                                    }).unwrap();
+                                        },
+                                    })
+                                    .unwrap();
                                     QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
-                                },
+                                }
                                 _ => {
-                                    let response : &str= &address.to_string();
+                                    let response: &str = &address.to_string();
                                     println!("{}", response);
-                                    unimplemented!("wrong tt address")   
-                                }                      
-
+                                    unimplemented!("wrong tt address")
+                                }
                             }
-                        },
+                        }
                         cosmwasm_std::BankQuery::AllBalances { address } => todo!(),
                         _ => todo!(),
                     }
-                },
+                }
                 QueryRequest::Custom(_) => todo!(),
-                QueryRequest::Wasm(msg) =>{ 
-                    match msg {
-                        cosmwasm_std::WasmQuery::Smart { contract_addr, code_hash, msg } => {
-                            match contract_addr.as_str(){
-                                FACTORY_CONTRACT_ADDRESS => {
-                                    let amm_settings = shadeswap_shared::amm_pair::AMMSettings {
-                                        lp_fee: Fee::new(28, 100),
-                                        shade_dao_fee: Fee::new(2, 100),
-                                        shade_dao_address: ContractLink {
-                                            address: Addr::unchecked("DAO"),
-                                            code_hash: "".to_string(),
-                                        }
-                                    };
-                                    let response = FactoryQueryResponse::GetAMMSettings {
-                                        settings: amm_settings
-                                    };
-                                    QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(to_binary(&response).unwrap()))
+                QueryRequest::Wasm(msg) => match msg {
+                    cosmwasm_std::WasmQuery::Smart {
+                        contract_addr,
+                        code_hash,
+                        msg,
+                    } => match contract_addr.as_str() {
+                        FACTORY_CONTRACT_ADDRESS => {
+                            let amm_settings = shadeswap_shared::amm_pair::AMMSettings {
+                                lp_fee: Fee::new(28, 100),
+                                shade_dao_fee: Fee::new(2, 100),
+                                shade_dao_address: ContractLink {
+                                    address: Addr::unchecked("DAO"),
+                                    code_hash: "".to_string(),
                                 },
-                                CUSTOM_TOKEN_1 => {
-                                    let balance = to_binary(&QueryAnswer::Balance { amount: Uint128::from(10000u128)}).unwrap();
-                                    QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
-                                },
-                                CUSTOM_TOKEN_2 => {
-                                    let balance = to_binary(&QueryAnswer::Balance { amount: Uint128::from(10000u128)}).unwrap();
-                                    QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
-                                },
-                                _ => {
-                                    let response : &str= &contract_addr.to_string();
-                                    println!("{}", response);
-                                    unimplemented!("wrong address")
-                                },
-                            }
-                        },
-                        cosmwasm_std::WasmQuery::ContractInfo { contract_addr } => todo!(),
-                        cosmwasm_std::WasmQuery::Raw { key, contract_addr } => todo!(),
-                        _ => todo!(),
-                    }
+                            };
+                            let response = FactoryQueryResponse::GetAMMSettings {
+                                settings: amm_settings,
+                            };
+                            QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(
+                                to_binary(&response).unwrap(),
+                            ))
+                        }
+                        CUSTOM_TOKEN_1 => {
+                            let balance = to_binary(&QueryAnswer::Balance {
+                                amount: Uint128::from(10000u128),
+                            })
+                            .unwrap();
+                            QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
+                        }
+                        CUSTOM_TOKEN_2 => {
+                            let balance = to_binary(&QueryAnswer::Balance {
+                                amount: Uint128::from(10000u128),
+                            })
+                            .unwrap();
+                            QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
+                        }
+                        _ => {
+                            let response: &str = &contract_addr.to_string();
+                            println!("{}", response);
+                            unimplemented!("wrong address")
+                        }
+                    },
+                    cosmwasm_std::WasmQuery::ContractInfo { contract_addr } => todo!(),
+                    cosmwasm_std::WasmQuery::Raw { key, contract_addr } => todo!(),
+                    _ => todo!(),
                 },
                 _ => todo!(),
             }
         }
     }
 
-    
     pub fn make_init_config_test_calculate_price_fee(
-        mut deps: DepsMut, 
+        mut deps: DepsMut,
         token_pair: TokenPair,
         custom_fee: Option<CustomFee>,
-    ) 
-    -> StdResult<Config> {    
+    ) -> StdResult<Config> {
         let seed = to_binary(&"SEED".to_string())?;
         let entropy = to_binary(&"ENTROPY".to_string())?;
-        let env = mock_custom_env(FACTORY_CONTRACT_ADDRESS);  
+        let env = mock_custom_env(FACTORY_CONTRACT_ADDRESS);
         /// let mut deps = mock_dependencies(&[]);
-        let mock_info = mock_info("CONTRACT_ADDRESS",&[]);
+        let mock_info = mock_info("CONTRACT_ADDRESS", &[]);
         let msg = InitMsg {
             pair: token_pair.clone(),
-            lp_token_contract: ContractInstantiationInfo{
-                  code_hash: "CODE_HASH".to_string(),
-                  id :0
+            lp_token_contract: ContractInstantiationInfo {
+                code_hash: "CODE_HASH".to_string(),
+                id: 0,
             },
             factory_info: ContractLink {
                 address: Addr::unchecked(FACTORY_CONTRACT_ADDRESS),
-                code_hash: "TEST".to_string()
+                code_hash: "TEST".to_string(),
             },
             prng_seed: seed.clone(),
             entropy: entropy.clone(),
-            admin: Some(mock_info.sender.clone()),          
+            admin: Some(mock_info.sender.clone()),
             staking_contract: None,
             custom_fee: custom_fee,
             callback: None,
-        };         
+        };
         let temp_deps = deps.branch();
-        assert!(instantiate(temp_deps, env.clone(),mock_info, msg).is_ok());
-        let config = config_r(deps.storage).load()?;    // set staking contract        
+        assert!(instantiate(temp_deps, env.clone(), mock_info, msg).is_ok());
+        let config = config_r(deps.storage).load()?; // set staking contract
         Ok(config)
     }
 
-    pub fn mk_token_pair_test_calculation_price_fee() -> TokenPair{
-        let pair =  TokenPair(
+    pub fn mk_token_pair_test_calculation_price_fee() -> TokenPair {
+        let pair = TokenPair(
             TokenType::CustomToken {
                 contract_addr: Addr::unchecked(CUSTOM_TOKEN_1.to_string().clone()),
-                token_code_hash: CUSTOM_TOKEN_1.to_string()
-            },            
+                token_code_hash: CUSTOM_TOKEN_1.to_string(),
+            },
             TokenType::CustomToken {
                 contract_addr: Addr::unchecked(CUSTOM_TOKEN_2.to_string().clone()),
-                token_code_hash: CUSTOM_TOKEN_2.to_string()
-            }
+                token_code_hash: CUSTOM_TOKEN_2.to_string(),
+            },
         );
         pair
     }
 
-    pub fn mk_custom_token_amount_test_calculation_price_fee(amount: Uint128, token_pair: TokenPair) -> TokenAmount{    
-        let token = TokenAmount{
+    pub fn mk_custom_token_amount_test_calculation_price_fee(
+        amount: Uint128,
+        token_pair: TokenPair,
+    ) -> TokenAmount {
+        let token = TokenAmount {
             token: token_pair.0.clone(),
             amount: amount.clone(),
         };
         token
     }
 
-    pub fn mk_native_token_pair_test_calculation_price_fee() -> TokenPair{
-        let pair =  TokenPair(
+    pub fn mk_native_token_pair_test_calculation_price_fee() -> TokenPair {
+        let pair = TokenPair(
             TokenType::CustomToken {
                 contract_addr: Addr::unchecked(CUSTOM_TOKEN_2.to_string()),
-                token_code_hash: CUSTOM_TOKEN_2.to_string()
-            },            
+                token_code_hash: CUSTOM_TOKEN_2.to_string(),
+            },
             TokenType::NativeToken {
-                denom: "uscrt".into()
-            }
+                denom: "uscrt".into(),
+            },
         );
         pair
-    }    
+    }
 }

--- a/contracts/factory/Cargo.toml
+++ b/contracts/factory/Cargo.toml
@@ -15,23 +15,10 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = true
-rpath = true
-lto = true
-debug-assertions = true
-codegen-units = 1
-panic = 'abort'
-incremental = true
-overflow-checks = true
-
 [features]
 default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-
-
 
 [dependencies]
 snafu = { version = "0.7.1" }
@@ -46,4 +33,4 @@ shadeswap-shared = {path = "../../packages/shadeswap-shared"}
 secret-multi-test = { git = "https://github.com/securesecrets/secret-plus-utils", version = "0.13.4" }
 
 [dev-dependencies]
-cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", commit = "1e05e7e" }
+cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", rev = "1e05e7e" }

--- a/contracts/lp_token/Cargo.toml
+++ b/contracts/lp_token/Cargo.toml
@@ -13,16 +13,7 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
+
 
 [features]
 # for quicker tests, cargo test --lib
@@ -51,4 +42,4 @@ sha2 = { version = "0.9.1", default-features = false }
 shadeswap-shared = {path = "../../packages/shadeswap-shared"}
 
 [dev-dependencies]
-cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", commit = "1e05e7e" }
+cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", rev = "1e05e7e" }

--- a/contracts/lp_token/tests/example-receiver/Cargo.toml
+++ b/contracts/lp_token/tests/example-receiver/Cargo.toml
@@ -15,16 +15,7 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
+
 
 [features]
 default = []

--- a/contracts/router/Cargo.toml
+++ b/contracts/router/Cargo.toml
@@ -15,16 +15,7 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
+
 
 [features]
 default = []
@@ -45,4 +36,4 @@ cosmwasm-storage = { git = "https://github.com/scrtlabs/cosmwasm", branch = "sec
 shadeswap-shared = {path = "../../packages/shadeswap-shared"}
 
 [dev-dependencies]
-cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", commit = "1e05e7e" }
+cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", rev = "1e05e7e" }

--- a/contracts/snip20/Cargo.toml
+++ b/contracts/snip20/Cargo.toml
@@ -13,16 +13,7 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
+
 
 [features]
 # for quicker tests, cargo test --lib
@@ -50,4 +41,4 @@ rand_core = { version = "0.5.1", default-features = false }
 sha2 = { version = "0.9.1", default-features = false }
 
 [dev-dependencies]
-cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", commit = "1e05e7e" }
+cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", rev = "1e05e7e" }

--- a/contracts/snip20/tests/example-receiver/Cargo.toml
+++ b/contracts/snip20/tests/example-receiver/Cargo.toml
@@ -15,16 +15,7 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
+
 
 [features]
 default = []

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -15,24 +15,10 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
-
 [features]
 default = []
 # for quicker tests, cargo test --lib
 # # for more explicit tests, cargo test --features=backtraces
-
-
-
 
 [dependencies]
 snafu = { version = "0.7.1" }
@@ -47,4 +33,4 @@ shadeswap-shared = {path = "../../packages/shadeswap-shared"}
 query-authentication = { git = "https://github.com/securesecrets/query-authentication", branch = "cosmwasm_v1_upgrade", optional = true }
 
 [dev-dependencies]
-cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", commit = "1e05e7e" }
+cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", rev = "1e05e7e" }

--- a/contracts/staking/src/operations.rs
+++ b/contracts/staking/src/operations.rs
@@ -546,11 +546,7 @@ pub fn try_proxy_stake(
                     }
                 }
 
-                for addr in remove {
-                    if current_whitelist.contains(&addr) {
-                        current_whitelist.retain(|a| a.ne(&addr));
-                    }
-                }
+                current_whitelist.retain(|a| !remove.contains(a));
 
                 whitelisted_proxy_stakers_w(deps.storage).save(&current_whitelist)?;
                 Ok(Response::default().add_attribute("action", "whitelist_proxy_stakers_update"))

--- a/contracts/staking/src/operations.rs
+++ b/contracts/staking/src/operations.rs
@@ -57,19 +57,12 @@ pub fn calculate_staker_shares(storage: &dyn Storage, amount: Uint128) -> StdRes
 }
 
 pub fn stake(
-    mut deps: DepsMut,
+    deps: DepsMut,
     env: Env,
-    info: MessageInfo,
+    _info: MessageInfo,
     amount: Uint128,
     from: Addr,
 ) -> StdResult<Response> {
-    // this is receiver for LP Token send to staking contract ->
-    let config = config_r(deps.storage).load()?;
-    if config.lp_token.address != info.sender {
-        return Err(StdError::generic_err(
-            "Token sent is not LP Token".to_string(),
-        ));
-    }
     // calculate staking for existing stakers without increasing amount
     let current_timestamp = Uint128::from((env.block.time.seconds() * 1000) as u128);
     claim_rewards_for_all_stakers(deps.storage, current_timestamp)?;
@@ -96,7 +89,7 @@ pub fn stake(
             caller.as_bytes(),
             &StakingInfo {
                 staker: caller.clone(),
-                amount: amount,
+                amount,
                 last_time_updated: current_timestamp,
             },
         )?;

--- a/contracts/staking/src/operations.rs
+++ b/contracts/staking/src/operations.rs
@@ -550,6 +550,7 @@ pub fn try_proxy_stake(
             amount,
             user,
         } => {
+            require_whitelisted_proxy_staker(storage, &info.sender)?;
             require_lp_token(storage, token)?;
             stake(deps, env, info, amount, user)
         }
@@ -558,6 +559,7 @@ pub fn try_proxy_stake(
             amount,
             user,
         } => {
+            require_whitelisted_proxy_staker(storage, &info.sender)?;
             require_lp_token(storage, token)?;
             // unstake uses MessageInfo to know who to stake for
             let new_info = MessageInfo {
@@ -576,5 +578,17 @@ pub fn require_lp_token(storage: &dyn Storage, token: Contract) -> StdResult<()>
         Ok(())
     } else {
         Err(StdError::generic_err(format!("Token of address {} and code hash {} does not equal the LP token address {} and code hash {} registered in the staking contract.", token.address, token.code_hash, config.lp_token.address, config.lp_token.code_hash)))
+    }
+}
+
+pub fn require_whitelisted_proxy_staker(storage: &dyn Storage, sender: &Addr) -> StdResult<()> {
+    let whitelist = whitelisted_proxy_stakers_r(storage).load()?;
+    if whitelist.contains(&sender) {
+        Ok(())
+    } else {
+        Err(StdError::generic_err(format!(
+            "Sender {} is not in the whitelist of proxy stakers.",
+            sender.clone()
+        )))
     }
 }

--- a/contracts/staking/src/state.rs
+++ b/contracts/staking/src/state.rs
@@ -1,9 +1,13 @@
-use cosmwasm_std::{Addr, Uint128, Storage, Decimal256};
-use cosmwasm_storage::{singleton, Singleton, ReadonlySingleton, singleton_read, bucket_read, bucket, ReadonlyBucket, Bucket};
-use serde::{Serialize, Deserialize};
-use shadeswap_shared::{core::{TokenType, ContractLink, ViewingKey}, Contract};
-
-
+use cosmwasm_std::{Addr, Decimal256, Storage, Uint128};
+use cosmwasm_storage::{
+    bucket, bucket_read, singleton, singleton_read, Bucket, ReadonlyBucket, ReadonlySingleton,
+    Singleton,
+};
+use serde::{Deserialize, Serialize};
+use shadeswap_shared::{
+    core::{ContractLink, TokenType, ViewingKey},
+    Contract,
+};
 
 pub static CONFIG: &[u8] = b"CONFIG";
 pub static STAKERS: &[u8] = b"LIST_STAKERS";
@@ -15,27 +19,29 @@ pub static STAKER_VK: &[u8] = b"STAKER_VK";
 pub static TOTAL_STAKERS: &[u8] = b"TOTAL_STAKERS";
 pub static TOTAL_STAKED: &[u8] = b"TOTAL_STAKED";
 pub static STAKER_INDEX: &[u8] = b"STAKER_INDEX";
+/// Whitelisted contracts that can stake and unstake on behalf of users while maintaining custody of the LP tokens
+pub static WHITELISTED_PROXY_STAKERS: &[u8] = b"WHITELISTED_PROXY_STAKERS";
 
-#[derive(Serialize, Deserialize,  PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Config {
     pub contract_owner: Addr,
     pub daily_reward_amount: Uint128,
     pub reward_token: TokenType,
     pub lp_token: ContractLink,
-    pub authenticator: Option<Contract>
+    pub authenticator: Option<Contract>,
 }
 
-#[derive(Serialize, Deserialize,  PartialEq, Debug)]
-pub struct StakingInfo{
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct StakingInfo {
     pub staker: Addr,
     pub amount: Uint128,
     pub last_time_updated: Uint128,
 }
 
-#[derive(Serialize, Deserialize,  PartialEq, Debug)]
-pub struct ClaimRewardsInfo{
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct ClaimRewardsInfo {
     pub amount: Uint128,
-    pub last_time_claimed: Uint128
+    pub last_time_claimed: Uint128,
 }
 
 pub fn config_w(storage: &mut dyn Storage) -> Singleton<Config> {
@@ -110,4 +116,10 @@ pub fn total_staked_r(storage: &dyn Storage) -> ReadonlySingleton<Uint128> {
     singleton_read(storage, TOTAL_STAKED)
 }
 
+pub fn whitelisted_proxy_stakers_w(storage: &mut dyn Storage) -> Singleton<Vec<Addr>> {
+    singleton(storage, WHITELISTED_PROXY_STAKERS)
+}
 
+pub fn whitelisted_proxy_stakers_r(storage: &dyn Storage) -> ReadonlySingleton<Vec<Addr>> {
+    singleton_read(storage, WHITELISTED_PROXY_STAKERS)
+}

--- a/contracts/staking/src/test.rs
+++ b/contracts/staking/src/test.rs
@@ -9,31 +9,54 @@ pub const STAKING_CONTRACT_ADDRESS: &str = "STAKING_CONTRACT_ADDRESS";
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use cosmwasm_std::{BankQuery, AllBalanceResponse, to_vec, Coin, StdResult, BalanceResponse, from_binary, StdError, QueryRequest, Empty, Uint128, to_binary, QuerierResult, from_slice, Querier, testing::{MockApi, MockStorage, mock_info}, MessageInfo, BlockInfo, Env, Api, Storage, WasmQuery, Addr, Decimal};
-    use shadeswap_shared::{msg::staking::{{InitMsg,QueryMsg,QueryResponse,  ExecuteMsg}}, core::{ContractLink, TokenType}};    
-    use shadeswap_shared::msg::factory::{QueryResponse as FactoryQueryResponse,QueryMsg as FactoryQueryMsg };
-    use crate::{test::test_help_lib::{mock_custom_env, make_init_config, mock_dependencies, mock_custom_env_b}, state::{Config, claim_reward_info_r, ClaimRewardsInfo}, operations::{calculate_staker_shares, stake, get_total_stakers_count, claim_rewards_for_all_stakers, calculate_staking_reward}};
+    use crate::{
+        operations::{
+            calculate_staker_shares, calculate_staking_reward, claim_rewards_for_all_stakers,
+            get_total_stakers_count, stake,
+        },
+        state::{claim_reward_info_r, ClaimRewardsInfo, Config},
+        test::test_help_lib::{
+            make_init_config, mock_custom_env, mock_custom_env_b, mock_dependencies,
+        },
+    };
+    use cosmwasm_std::{
+        from_binary, from_slice,
+        testing::{mock_info, MockApi, MockStorage},
+        to_binary, to_vec, Addr, AllBalanceResponse, Api, BalanceResponse, BankQuery, BlockInfo,
+        Coin, Decimal, Empty, Env, MessageInfo, Querier, QuerierResult, QueryRequest, StdError,
+        StdResult, Storage, Uint128, WasmQuery,
+    };
     use serde::Deserialize;
-    use serde::Serialize; 
-    
+    use serde::Serialize;
+    use shadeswap_shared::msg::factory::{
+        QueryMsg as FactoryQueryMsg, QueryResponse as FactoryQueryResponse,
+    };
+    use shadeswap_shared::{
+        core::{ContractLink, TokenType},
+        msg::staking::{ExecuteMsg, InitMsg, QueryMsg, QueryResponse},
+    };
+
     #[test]
-    fn assert_init_config() -> StdResult<()> {   
-        let mut deps = mock_dependencies(&[]);  
-        let env = mock_custom_env(CONTRACT_ADDRESS,1571797523, 1524);
-        let config: Config = make_init_config(deps.as_mut(), env, Uint128::from(100u128))?;        
+    fn assert_init_config() -> StdResult<()> {
+        let mut deps = mock_dependencies(&[]);
+        let env = mock_custom_env(CONTRACT_ADDRESS, 1571797523, 1524);
+        let config: Config = make_init_config(deps.as_mut(), env, Uint128::from(100u128))?;
         assert_eq!(config.daily_reward_amount, Uint128::from(100u128));
-        assert_eq!(config.reward_token, TokenType::CustomToken{
-            contract_addr: Addr::unchecked(CONTRACT_ADDRESS),
-            token_code_hash: CONTRACT_ADDRESS.to_string(),
-        });
+        assert_eq!(
+            config.reward_token,
+            TokenType::CustomToken {
+                contract_addr: Addr::unchecked(CONTRACT_ADDRESS),
+                token_code_hash: CONTRACT_ADDRESS.to_string(),
+            }
+        );
         Ok(())
     }
 
     #[test]
-    fn assert_calculate_user_share_first_return_100() -> StdResult<()>{
+    fn assert_calculate_user_share_first_return_100() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
-        let env = mock_custom_env(CONTRACT_ADDRESS,1571797523, 1524);
-        let config: Config = make_init_config(deps.as_mut(), env, Uint128::from(100u128))?;       
+        let env = mock_custom_env(CONTRACT_ADDRESS, 1571797523, 1524);
+        let config: Config = make_init_config(deps.as_mut(), env, Uint128::from(100u128))?;
         let user_shares = calculate_staker_shares(deps.as_mut().storage, Uint128::from(100u128))?;
         assert_eq!(user_shares, Decimal::zero());
         Ok(())
@@ -43,49 +66,103 @@ pub mod tests {
     // amount = 500
     // share = 500/1500 = 0.33333333333333333
     #[test]
-    fn assert_calculate_user_share_already_return_() -> StdResult<()>{
+    fn assert_calculate_user_share_already_return_() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
-        let env = mock_custom_env(CONTRACT_ADDRESS,1571797523, 1524);
+        let env = mock_custom_env(CONTRACT_ADDRESS, 1571797523, 1524);
         let mock_info = mock_info(LP_TOKEN, &[]);
         let config: Config = make_init_config(deps.as_mut(), env.clone(), Uint128::from(100u128))?;
-        let stake = stake(deps.as_mut(), env.clone(),mock_info.clone(), Uint128::from(1500u128),Addr::unchecked("Staker"))?;       
+        let stake = stake(
+            deps.as_mut(),
+            env.clone(),
+            mock_info.clone(),
+            Uint128::from(1500u128),
+            Addr::unchecked("Staker"),
+        )?;
         let user_shares = calculate_staker_shares(deps.as_mut().storage, Uint128::from(500u128))?;
-        assert_eq!(user_shares, Decimal::from_atomics(Uint128::new(333333333333333333), 18).unwrap());
+        assert_eq!(
+            user_shares,
+            Decimal::from_atomics(Uint128::new(333333333333333333), 18).unwrap()
+        );
         Ok(())
     }
 
     #[test]
-    fn assert_get_total_stakers_count_return_3() -> StdResult<()>{
+    fn assert_get_total_stakers_count_return_3() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
-        let env = mock_custom_env(CONTRACT_ADDRESS,1571797523, 1524);
-        let env_b = mock_custom_env(CONTRACT_ADDRESS,1571797854, 1534);
+        let env = mock_custom_env(CONTRACT_ADDRESS, 1571797523, 1524);
+        let env_b = mock_custom_env(CONTRACT_ADDRESS, 1571797854, 1534);
         let mock_info = mock_info(LP_TOKEN, &[]);
         let config: Config = make_init_config(deps.as_mut(), env.clone(), Uint128::from(100u128))?;
-        let stake_a = stake(deps.as_mut(), env.clone(),mock_info.clone(), Uint128::from(1000u128),Addr::unchecked("StakerA"))?;    
-        let stake_b = stake(deps.as_mut(), env.clone(),mock_info.clone(), Uint128::from(1500u128),Addr::unchecked("StakerB"))?;       
-        let stake_c = stake(deps.as_mut(), env.clone(),mock_info.clone(), Uint128::from(1700u128),Addr::unchecked("StakerC"))?;   
-        let stake_a = stake(deps.as_mut(), env.clone(),mock_info.clone(), Uint128::from(1000u128),Addr::unchecked("StakerA"))?;           
+        let stake_a = stake(
+            deps.as_mut(),
+            env.clone(),
+            mock_info.clone(),
+            Uint128::from(1000u128),
+            Addr::unchecked("StakerA"),
+        )?;
+        let stake_b = stake(
+            deps.as_mut(),
+            env.clone(),
+            mock_info.clone(),
+            Uint128::from(1500u128),
+            Addr::unchecked("StakerB"),
+        )?;
+        let stake_c = stake(
+            deps.as_mut(),
+            env.clone(),
+            mock_info.clone(),
+            Uint128::from(1700u128),
+            Addr::unchecked("StakerC"),
+        )?;
+        let stake_a = stake(
+            deps.as_mut(),
+            env.clone(),
+            mock_info.clone(),
+            Uint128::from(1000u128),
+            Addr::unchecked("StakerA"),
+        )?;
         let total_stakers_count = get_total_stakers_count(deps.as_mut().storage);
         assert_eq!(total_stakers_count, Uint128::from(3u128));
         Ok(())
     }
 
     #[test]
-    fn assert_staking_with_claim_rewards() -> StdResult<()>{
+    fn assert_staking_with_claim_rewards() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
-        let env = mock_custom_env(CONTRACT_ADDRESS,15000000, 1500);
-        let env_b = mock_custom_env(CONTRACT_ADDRESS,16000000, 1534);
+        let env = mock_custom_env(CONTRACT_ADDRESS, 15000000, 1500);
+        let env_b = mock_custom_env(CONTRACT_ADDRESS, 16000000, 1534);
         let mock_info = mock_info(LP_TOKEN, &[]);
-        let config: Config = make_init_config(deps.as_mut(), env.clone(), Uint128::from(300000u128))?;
-        let stake_a = stake(deps.as_mut(), env.clone(),mock_info.clone(), Uint128::from(1000u128),Addr::unchecked("StakerA"))?;    
-        let stake_b = stake(deps.as_mut(), env_b.clone(),mock_info.clone(), Uint128::from(1500u128),Addr::unchecked("StakerB"))?;    
-        claim_rewards_for_all_stakers(deps.as_mut().storage,Uint128::from(16000000u128))?;
-        let claim_reward_info_a: ClaimRewardsInfo  = claim_reward_info_r(deps.as_mut().storage).load(Addr::unchecked("StakerA").as_bytes())?;
-        let claim_reward_info_b: ClaimRewardsInfo  = claim_reward_info_r(deps.as_mut().storage).load(Addr::unchecked("StakerB").as_bytes())?;
+        let config: Config =
+            make_init_config(deps.as_mut(), env.clone(), Uint128::from(300000u128))?;
+        let stake_a = stake(
+            deps.as_mut(),
+            env.clone(),
+            mock_info.clone(),
+            Uint128::from(1000u128),
+            Addr::unchecked("StakerA"),
+        )?;
+        let stake_b = stake(
+            deps.as_mut(),
+            env_b.clone(),
+            mock_info.clone(),
+            Uint128::from(1500u128),
+            Addr::unchecked("StakerB"),
+        )?;
+        claim_rewards_for_all_stakers(deps.as_mut().storage, Uint128::from(16000000u128))?;
+        let claim_reward_info_a: ClaimRewardsInfo = claim_reward_info_r(deps.as_mut().storage)
+            .load(Addr::unchecked("StakerA").as_bytes())?;
+        let claim_reward_info_b: ClaimRewardsInfo = claim_reward_info_r(deps.as_mut().storage)
+            .load(Addr::unchecked("StakerB").as_bytes())?;
         assert_eq!(claim_reward_info_a.amount, Uint128::from(22222u128));
         assert_eq!(claim_reward_info_b.amount, Uint128::from(33333u128));
-        assert_eq!(claim_reward_info_a.last_time_claimed, Uint128::from(16000000u128));
-        assert_eq!(claim_reward_info_b.last_time_claimed, Uint128::from(16000000u128));
+        assert_eq!(
+            claim_reward_info_a.last_time_claimed,
+            Uint128::from(16000000u128)
+        );
+        assert_eq!(
+            claim_reward_info_b.last_time_claimed,
+            Uint128::from(16000000u128)
+        );
         Ok(())
     }
 
@@ -95,73 +172,116 @@ pub mod tests {
     // stake -> staker_a 15000000time -> 1000amount
     // stake -> staker_b 16000000time -> 1500amount
     // 1. (300000 * 10000000 / 86400000) * 0.4 = 1388-> Staker A
-    // 
+    //
     #[test]
-    fn assert_calculate_staking_reward() -> StdResult<()>{
+    fn assert_calculate_staking_reward() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
-        let env = mock_custom_env(CONTRACT_ADDRESS,15000000, 1500);
-        let env_b = mock_custom_env(CONTRACT_ADDRESS,16000000, 1534);
+        let env = mock_custom_env(CONTRACT_ADDRESS, 15000000, 1500);
+        let env_b = mock_custom_env(CONTRACT_ADDRESS, 16000000, 1534);
         let mock_info = mock_info(LP_TOKEN, &[]);
-        let config: Config = make_init_config(deps.as_mut(), env.clone(), Uint128::from(300000u128))?;
-        let stake_a = stake(deps.as_mut(), env.clone(),mock_info.clone(), Uint128::from(1000u128),Addr::unchecked("StakerA"))?;    
-        let stake_b = stake(deps.as_mut(), env_b.clone(),mock_info.clone(), Uint128::from(1500u128),Addr::unchecked("StakerB"))?;   
+        let config: Config =
+            make_init_config(deps.as_mut(), env.clone(), Uint128::from(300000u128))?;
+        let stake_a = stake(
+            deps.as_mut(),
+            env.clone(),
+            mock_info.clone(),
+            Uint128::from(1000u128),
+            Addr::unchecked("StakerA"),
+        )?;
+        let stake_b = stake(
+            deps.as_mut(),
+            env_b.clone(),
+            mock_info.clone(),
+            Uint128::from(1500u128),
+            Addr::unchecked("StakerB"),
+        )?;
         let last_timestamp = Uint128::from(15000000u128);
-        let current_timestamp  = Uint128::from(16000000u128);
-        let staking_reward = calculate_staking_reward(deps.as_mut().storage, Uint128::from(1000u128),last_timestamp, current_timestamp)?;
-        assert_eq!(staking_reward, Uint128::from(1388u128));       
+        let current_timestamp = Uint128::from(16000000u128);
+        let staking_reward = calculate_staking_reward(
+            deps.as_mut().storage,
+            Uint128::from(1000u128),
+            last_timestamp,
+            current_timestamp,
+        )?;
+        assert_eq!(staking_reward, Uint128::from(1388u128));
         Ok(())
     }
 
     #[test]
-    fn assert_staking_first_time_store_timestamp() -> StdResult<()>{
+    fn assert_staking_first_time_store_timestamp() -> StdResult<()> {
         let mut deps = mock_dependencies(&[]);
-        let env = mock_custom_env_b(CONTRACT_ADDRESS,15000000, 1500);        
+        let env = mock_custom_env_b(CONTRACT_ADDRESS, 15000000, 1500);
         let mock_info = mock_info(LP_TOKEN, &[]);
-        let config: Config = make_init_config(deps.as_mut(), env.clone(), Uint128::from(300000u128))?;
-        let stake_a = stake(deps.as_mut(), env.clone(),mock_info.clone(), Uint128::from(1000u128),Addr::unchecked("StakerA"))?;    
-        let claim_reward_info_b: ClaimRewardsInfo  = claim_reward_info_r(deps.as_mut().storage).load(Addr::unchecked("StakerA").as_bytes())?;
+        let config: Config =
+            make_init_config(deps.as_mut(), env.clone(), Uint128::from(300000u128))?;
+        let stake_a = stake(
+            deps.as_mut(),
+            env.clone(),
+            mock_info.clone(),
+            Uint128::from(1000u128),
+            Addr::unchecked("StakerA"),
+        )?;
+        let claim_reward_info_b: ClaimRewardsInfo = claim_reward_info_r(deps.as_mut().storage)
+            .load(Addr::unchecked("StakerA").as_bytes())?;
         assert_eq!(claim_reward_info_b.amount, Uint128::zero());
-        assert_eq!(claim_reward_info_b.last_time_claimed, Uint128::from(15000000u128));       
+        assert_eq!(
+            claim_reward_info_b.last_time_claimed,
+            Uint128::from(15000000u128)
+        );
         Ok(())
     }
 }
 
 #[cfg(test)]
-pub mod test_help_lib{
+pub mod test_help_lib {
     use super::*;
-    use cosmwasm_std::{Uint128, DepsMut, Env, StdResult, Addr, testing::{mock_info, MockStorage, MockApi}, BlockInfo, TransactionInfo, ContractInfo, Timestamp, to_binary, OwnedDeps, Coin, Querier, QuerierResult, BalanceResponse, from_slice, Empty, QueryRequest};
+    use cosmwasm_std::{
+        from_slice,
+        testing::{mock_info, MockApi, MockStorage},
+        to_binary, Addr, BalanceResponse, BlockInfo, Coin, ContractInfo, DepsMut, Empty, Env,
+        OwnedDeps, Querier, QuerierResult, QueryRequest, StdResult, Timestamp, TransactionInfo,
+        Uint128,
+    };
     use serde::{Deserialize, Serialize};
-    use shadeswap_shared::{staking::InitMsg, core::{TokenType, ContractLink, Fee}, snip20::{QueryAnswer, manager::Balance}};
+    use shadeswap_shared::{
+        core::{ContractLink, Fee, TokenType},
+        snip20::{manager::Balance, QueryAnswer},
+        staking::InitMsg,
+    };
 
-    use crate::{state::{Config, config_r, config_w}, contract::instantiate};
+    use crate::{
+        contract::instantiate,
+        state::{config_r, config_w, Config},
+    };
 
-    pub fn make_init_config(
-            mut deps: DepsMut, 
-            env: Env,
-            amount: Uint128
-        ) -> StdResult<Config> 
-    {    
+    pub fn make_init_config(mut deps: DepsMut, env: Env, amount: Uint128) -> StdResult<Config> {
         let info = mock_info("Sender", &[]);
         let msg = InitMsg {
-            staking_amount: amount.clone(),         
-            reward_token: TokenType::CustomToken{
+            staking_amount: amount.clone(),
+            reward_token: TokenType::CustomToken {
                 contract_addr: Addr::unchecked(CONTRACT_ADDRESS),
                 token_code_hash: CONTRACT_ADDRESS.to_string(),
-            },           
+            },
             pair_contract: ContractLink {
                 address: Addr::unchecked(CONTRACT_ADDRESS),
                 code_hash: "".to_string().clone(),
             },
             prng_seed: to_binary(&"prng")?,
-            lp_token: ContractLink { address: Addr::unchecked("".to_string()), code_hash: "".to_string() },
-        };         
-        assert!(instantiate(deps.branch(), env.clone(),info.clone(), msg).is_ok());
+            lp_token: ContractLink {
+                address: Addr::unchecked("".to_string()),
+                code_hash: "".to_string(),
+            },
+        };
+        assert!(instantiate(deps.branch(), env.clone(), info.clone(), msg).is_ok());
         let mut config = config_r(deps.storage).load()?;
-        config.lp_token = ContractLink{ address: Addr::unchecked(LP_TOKEN), code_hash: "".to_string() };
+        config.lp_token = ContractLink {
+            address: Addr::unchecked(LP_TOKEN),
+            code_hash: "".to_string(),
+        };
         config_w(deps.storage).save(&config)?;
         Ok(config)
     }
-  
+
     pub fn mock_custom_env(address: &str, height: u64, time: u64) -> Env {
         Env {
             block: BlockInfo {
@@ -194,97 +314,100 @@ pub mod test_help_lib{
 
     pub fn mock_dependencies(
         contract_balance: &[Coin],
-      ) -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
+    ) -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
         let contract_addr = Addr::unchecked(CONTRACT_ADDRESS);
         OwnedDeps {
-          storage: MockStorage::default(),
-          api: MockApi::default(),
-          querier: MockQuerier{portion :100},
-            custom_query_type: std::marker::PhantomData,      
+            storage: MockStorage::default(),
+            api: MockApi::default(),
+            querier: MockQuerier { portion: 100 },
+            custom_query_type: std::marker::PhantomData,
         }
-      }
+    }
 
     #[derive(Serialize, Deserialize)]
     struct IntBalanceResponse {
         pub balance: Balance,
     }
-      
-    pub struct MockQuerier{
+
+    pub struct MockQuerier {
         portion: u128,
     }
-    
+
     impl Querier for MockQuerier {
-        fn raw_query (&self, bin_request: &[u8]) -> QuerierResult {
+        fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
             let request: QueryRequest<Empty> = from_slice(bin_request).unwrap();
             match &request {
-                QueryRequest::Bank(msg) => {
-                    match msg {
-                        cosmwasm_std::BankQuery::Balance { address, denom } => {
-                            match address.as_str() {
-                                CUSTOM_TOKEN_2 => {
-                                    let balance = to_binary(&QueryAnswer::Balance { amount: Uint128::from(1000u128)}).unwrap();
-                                    QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
+                QueryRequest::Bank(msg) => match msg {
+                    cosmwasm_std::BankQuery::Balance { address, denom } => match address.as_str() {
+                        CUSTOM_TOKEN_2 => {
+                            let balance = to_binary(&QueryAnswer::Balance {
+                                amount: Uint128::from(1000u128),
+                            })
+                            .unwrap();
+                            QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
+                        }
+                        FACTORY_CONTRACT_ADDRESS => {
+                            let balance = to_binary(&BalanceResponse {
+                                amount: Coin {
+                                    denom: "uscrt".into(),
+                                    amount: Uint128::from(1000000u128),
                                 },
-                                FACTORY_CONTRACT_ADDRESS => {
-                                    let balance = to_binary(&BalanceResponse{
-                                        amount: Coin{
-                                            denom: "uscrt".into(),
-                                            amount: Uint128::from(1000000u128),
-                                        }
-                                    }).unwrap();                                  
-                                    QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
+                            })
+                            .unwrap();
+                            QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
+                        }
+                        CUSTOM_TOKEN_1 => {
+                            let balance = to_binary(&BalanceResponse {
+                                amount: Coin {
+                                    denom: "uscrt".into(),
+                                    amount: Uint128::from(1000000u128),
                                 },
-                                CUSTOM_TOKEN_1 => {
-                                    let balance = to_binary(&BalanceResponse{
-                                        amount: Coin{
-                                            denom: "uscrt".into(),
-                                            amount: Uint128::from(1000000u128),
-                                        }
-                                    }).unwrap();
-                                    QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
-                                },
-                                _ => {
-                                    let response : &str= &address.to_string();
-                                    println!("{}", response);
-                                    unimplemented!("wrong tt address")   
-                                }                      
-
-                            }
-                        },
-                        cosmwasm_std::BankQuery::AllBalances { address } => todo!(),
-                        _ => todo!(),
-                    }
+                            })
+                            .unwrap();
+                            QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
+                        }
+                        _ => {
+                            let response: &str = &address.to_string();
+                            println!("{}", response);
+                            unimplemented!("wrong tt address")
+                        }
+                    },
+                    cosmwasm_std::BankQuery::AllBalances { address } => todo!(),
+                    _ => todo!(),
                 },
                 QueryRequest::Custom(_) => todo!(),
-                QueryRequest::Wasm(msg) =>{ 
-                    match msg {
-                        cosmwasm_std::WasmQuery::Smart { contract_addr, code_hash, msg } => {
-                            match contract_addr.as_str(){                              
-                                CUSTOM_TOKEN_1 => {
-                                    let balance = to_binary(&QueryAnswer::Balance { amount: Uint128::from(10000u128)}).unwrap();
-                                    QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
-                                },
-                                CUSTOM_TOKEN_2 => {
-                                    let balance = to_binary(&QueryAnswer::Balance { amount: Uint128::from(10000u128)}).unwrap();
-                                    QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
-                                },
-                                _ => {
-                                    let response : &str= &contract_addr.to_string();
-                                    println!("{}", response);
-                                    unimplemented!("wrong address")
-                                },
-                            }
-                        },
-                        cosmwasm_std::WasmQuery::ContractInfo { contract_addr } => todo!(),
-                        cosmwasm_std::WasmQuery::Raw { key, contract_addr } => todo!(),
-                        _ => todo!(),
-                    }
+                QueryRequest::Wasm(msg) => match msg {
+                    cosmwasm_std::WasmQuery::Smart {
+                        contract_addr,
+                        code_hash,
+                        msg,
+                    } => match contract_addr.as_str() {
+                        CUSTOM_TOKEN_1 => {
+                            let balance = to_binary(&QueryAnswer::Balance {
+                                amount: Uint128::from(10000u128),
+                            })
+                            .unwrap();
+                            QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
+                        }
+                        CUSTOM_TOKEN_2 => {
+                            let balance = to_binary(&QueryAnswer::Balance {
+                                amount: Uint128::from(10000u128),
+                            })
+                            .unwrap();
+                            QuerierResult::Ok(cosmwasm_std::ContractResult::Ok(balance))
+                        }
+                        _ => {
+                            let response: &str = &contract_addr.to_string();
+                            println!("{}", response);
+                            unimplemented!("wrong address")
+                        }
+                    },
+                    cosmwasm_std::WasmQuery::ContractInfo { contract_addr } => todo!(),
+                    cosmwasm_std::WasmQuery::Raw { key, contract_addr } => todo!(),
+                    _ => todo!(),
                 },
                 _ => todo!(),
             }
         }
     }
 }
-   
-
-

--- a/packages/shadeswap-shared/Cargo.toml
+++ b/packages/shadeswap-shared/Cargo.toml
@@ -15,16 +15,7 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
+
 
 [features]
 default = []
@@ -36,7 +27,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive", "
 schemars = "0.8.9"
 cosmwasm-std = { git = "https://github.com/scrtlabs/cosmwasm", branch = "secret" }
 cosmwasm-storage = { git = "https://github.com/scrtlabs/cosmwasm", branch = "secret" }
-cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", commit = "1e05e7e" }
+cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm", rev = "1e05e7e" }
 snip20-reference-impl = { path = "../../contracts/snip20"}
 sha2 = { version = "0.9.1", default-features = false }
 subtle = { version = "2.2.3", default-features = false }

--- a/packages/shadeswap-shared/src/msg.rs
+++ b/packages/shadeswap-shared/src/msg.rs
@@ -33,7 +33,7 @@ pub mod router {
         pub prng_seed: Binary,
         pub entropy: Binary,
         pub viewing_key: Option<String>,
-        pub pair_contract_code_hash: String
+        pub pair_contract_code_hash: String,
     }
 
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -81,7 +81,7 @@ pub mod router {
         },
         GetConfig {
             pair_contract_code_hash: String,
-        }
+        },
     }
 }
 
@@ -193,7 +193,7 @@ pub mod amm_pair {
     #[derive(Serialize, Deserialize, JsonSchema)]
     #[serde(rename_all = "snake_case")]
     pub enum QueryMsg {
-        GetConfig{},
+        GetConfig {},
         GetPairInfo {},
         GetTradeHistory {
             pagination: Pagination,
@@ -266,13 +266,13 @@ pub mod amm_pair {
             lp_token: Uint128,
             total_lp_token: Uint128,
         },
-        GetConfig{
+        GetConfig {
             factory_contract: ContractLink,
             lp_token: ContractLink,
             staking_contract: Option<ContractLink>,
             pair: TokenPair,
-            custom_fee: Option<CustomFee>
-        }
+            custom_fee: Option<CustomFee>,
+        },
     }
 }
 
@@ -354,11 +354,11 @@ pub mod factory {
 }
 
 pub mod staking {
-    use crate::{core::TokenType, query_auth::QueryPermit};
+    use crate::{core::TokenType, query_auth::QueryPermit, Contract};
 
     use super::*;
     use cosmwasm_schema::cw_serde;
-    use cosmwasm_std::Addr;
+    use cosmwasm_std::{Addr, ContractInfo};
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
 
@@ -386,7 +386,26 @@ pub mod staking {
             from: Addr,
             msg: Option<Binary>,
             amount: Uint128,
-        }
+        },
+        ProxyStake(ProxyStakeMsg),
+    }
+
+    #[cw_serde]
+    pub enum ProxyStakeMsg {
+        UpdateWhitelist {
+            add: Vec<Addr>,
+            remove: Vec<Addr>,
+        },
+        Stake {
+            token: Contract,
+            amount: Uint128,
+            user: Addr,
+        },
+        Unstake {
+            token: Contract,
+            amount: Uint128,
+            user: Addr,
+        },
     }
 
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -403,17 +422,14 @@ pub mod staking {
         WithPermit {
             permit: QueryPermit,
             query: AuthQuery,
-        }
+        },
     }
 
     #[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Clone)]
     #[serde(rename_all = "snake_case")]
     pub enum AuthQuery {
-        GetStakerLpTokenInfo {
-        },
-        GetClaimReward {
-            time: Uint128,
-        }
+        GetStakerLpTokenInfo {},
+        GetClaimReward { time: Uint128 },
     }
 
     #[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq)]
@@ -444,6 +460,7 @@ pub mod staking {
             lp_token: ContractLink,
             daily_reward_amount: Uint128,
             contract_owner: Addr,
+            whitelisted_proxy_stakers: Vec<Addr>,
         },
     }
 }

--- a/packages/shadeswap-shared/src/utils/asset.rs
+++ b/packages/shadeswap-shared/src/utils/asset.rs
@@ -112,8 +112,6 @@ impl From<ContractInfo> for RawContract {
 
 #[derive(Hash, Eq)]
 #[cw_serde]
-/// In the process of being deprecated for [cosmwasm_std::ContractInfo] so use that
-/// instead when possible.
 pub struct Contract {
     pub address: Addr,
     pub code_hash: String,


### PR DESCRIPTION
Implements a new feature called proxy staking.

The contract admin can manage a whitelist of allowed "proxy stakers" who are allowed to proxy stake on behalf of other users.

Proxy staking would be a user depositing their LP into a contract that isn't the staking contract, but still getting staking rewards.

For example, a user can deposit unstaked LP tokens into a Shade Lend vault to use as collateral. The vault contract can _proxy stake_ the user's collateral so that the user can still gain staking rewards. This way, the user does not have to choose between using the LP to get staking rewards and using the LP as collateral on Lend.

This PR contains a handful of other non-intrusive code improvements like running the code formatter, removing some redundant code, and fixing some clippy warnings. The primary changes in this PR are in the staking contract.