### PR TITLE
Goji-75 sslp

### DIFF
--- a/contracts/amm_pair/src/contract.rs
+++ b/contracts/amm_pair/src/contract.rs
@@ -297,15 +297,15 @@ fn receiver_callback(
                     "No matching token in pair".to_string(),
                 ))
             }
-            InvokeMsg::RemoveLiquidity { from } => {
+            InvokeMsg::RemoveLiquidity { from, single_sided, single_sided_withdraw_in_token0} => {
                 if config.lp_token.address != info.sender {
                     return Err(StdError::generic_err(
                         "LP Token was not sent to remove liquidity.".to_string(),
                     ));
                 }
                 match from {
-                    Some(address) => remove_liquidity(deps, env, amount, address),
-                    None => remove_liquidity(deps, env, amount, from_caller),
+                    Some(address) => remove_liquidity(deps, env, amount, address, single_sided, single_sided_withdraw_in_token0),
+                    None => remove_liquidity(deps, env, amount, from_caller, single_sided, single_sided_withdraw_in_token0),
                 }
             }
         },

--- a/contracts/amm_pair/src/contract.rs
+++ b/contracts/amm_pair/src/contract.rs
@@ -297,15 +297,15 @@ fn receiver_callback(
                     "No matching token in pair".to_string(),
                 ))
             }
-            InvokeMsg::RemoveLiquidity { from, single_sided, single_sided_withdraw_in_token0} => {
+            InvokeMsg::RemoveLiquidity { from, single_sided_withdraw_type, single_sided_expected_return } => {
                 if config.lp_token.address != info.sender {
                     return Err(StdError::generic_err(
                         "LP Token was not sent to remove liquidity.".to_string(),
                     ));
                 }
                 match from {
-                    Some(address) => remove_liquidity(deps, env, amount, address, single_sided, single_sided_withdraw_in_token0),
-                    None => remove_liquidity(deps, env, amount, from_caller, single_sided, single_sided_withdraw_in_token0),
+                    Some(address) => remove_liquidity(deps, env, amount, address, single_sided_withdraw_type, single_sided_expected_return),
+                    None => remove_liquidity(deps, env, amount, from_caller, single_sided_withdraw_type, single_sided_expected_return),
                 }
             }
         },

--- a/contracts/amm_pair/src/contract.rs
+++ b/contracts/amm_pair/src/contract.rs
@@ -369,7 +369,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             QueryMsg::SwapSimulation { offer } => swap_simulation(deps, env, offer),
             QueryMsg::GetShadeDaoInfo {} => get_shade_dao_info(deps),
             QueryMsg::GetEstimatedLiquidity { deposit } => {
-                get_estimated_lp_token(deps, env, deposit)
+                get_estimated_lp_token(deps, env, &deposit)
             }
             QueryMsg::GetConfig {} => {
                 let config = config_r(deps.storage).load()?;

--- a/contracts/amm_pair/src/operations.rs
+++ b/contracts/amm_pair/src/operations.rs
@@ -661,8 +661,10 @@ pub fn add_liquidity(
     let mut new_deposit = deposit.clone();
 
     //determine which token should be swapped for other
-    let token0_input_ratio_larger: bool = deposit.amount_0 / pool_balances[0] > deposit.amount_1 / pool_balances[1];
-    if token0_input_ratio_larger {
+    let ten_to_18th = Uint128::from(1_000_000_000_000_000_000u128);
+    let token0_ratio = (deposit.amount_0 * ten_to_18th) / pool_balances[0];
+    let token1_ratio = (deposit.amount_1 * ten_to_18th) / pool_balances[1];
+    if token0_ratio > token1_ratio {
         let extra_token0_amount = deposit.amount_0 - pool_balances[0].multiply_ratio(deposit.amount_1, pool_balances[1]);
         let half_of_extra = extra_token0_amount / Uint128::from(2u32);
         let offer = TokenAmount { token: deposit.pair.0, amount: half_of_extra };
@@ -677,7 +679,7 @@ pub fn add_liquidity(
 
         new_deposit.amount_0 = deposit.amount_0 - half_of_extra;
         new_deposit.amount_1 = deposit.amount_1 + swap_return;
-    } else {
+    } else if token1_ratio > token0_ratio {
         let extra_token1_amount = deposit.amount_1 - pool_balances[1].multiply_ratio(deposit.amount_0, pool_balances[0]);
         let half_of_extra = extra_token1_amount / Uint128::from(2u32);
         let offer = TokenAmount { token: deposit.pair.1, amount: half_of_extra };

--- a/contracts/amm_pair/src/test.rs
+++ b/contracts/amm_pair/src/test.rs
@@ -292,12 +292,13 @@ pub mod tests_calculation_price_and_fee {
 
     use super::*;
 
-    use cosmwasm_std::Decimal;
+    use cosmwasm_std::{Decimal, from_binary};
 
     use shadeswap_shared::core::{CustomFee, Fee, TokenPairAmount};
+    use shadeswap_shared::msg::amm_pair::QueryMsgResponse;
 
     use crate::operations::{
-        add_liquidity, add_whitelist_address, calculate_price, calculate_swap_result, swap, remove_liquidity,
+        add_liquidity, add_whitelist_address, calculate_price, calculate_swap_result, swap, remove_liquidity, get_estimated_lp_token,
     };
 
     use crate::test::help_test_lib::{
@@ -562,6 +563,40 @@ pub mod tests_calculation_price_and_fee {
         assert_eq!(withdraw0, Uint128::zero());
         assert!(withdraw1 > Uint128::from(100u32));
 
+    }
+
+    #[test]
+    fn assert_estimation_works_for_imbalanced_liquidity() {
+        let mut deps = mock_dependencies(&[]);
+        let token_pair = mk_token_pair_test_calculation_price_fee();
+        make_init_config_test_calculate_price_fee(deps.as_mut(), token_pair.clone(), None,Some(LP_TOKEN.to_string())).unwrap();              
+        let mock_info = mock_info("Sender", &[]);
+
+        let deposit = TokenPairAmount{
+                pair: token_pair.clone(),
+                amount_0: Uint128::from(200u128),
+                amount_1: Uint128::from(100u128)
+            };
+
+        let estimated_lp_bin = get_estimated_lp_token(deps.as_ref(), mock_env(), &deposit).unwrap();
+        let msg = from_binary::<QueryMsgResponse>(&estimated_lp_bin).unwrap();
+        let estimated_lp = match msg {
+            QueryMsgResponse::EstimatedLiquidity { lp_token, total_lp_token: _ } => lp_token,
+            _ => { panic!("Unexpected msg type from estimated lp") },
+        };
+
+        let add_result= add_liquidity(
+            deps.as_mut(),
+            mock_env(),
+            &mock_info,
+            deposit,
+            None,
+            None
+        );
+        let response = add_result.expect("Unwrap of add liquidity response failed");
+        let lp_tokens_received = Uint128::from_str(&response.attributes.get(3).unwrap().value).unwrap();
+
+        assert_eq!(lp_tokens_received, estimated_lp);
     }
 
     #[test]

--- a/contracts/amm_pair/src/test.rs
+++ b/contracts/amm_pair/src/test.rs
@@ -305,7 +305,7 @@ pub mod tests_calculation_price_and_fee {
         make_init_config_test_calculate_price_fee, mk_amm_settings_a,
         mk_custom_token_amount_test_calculation_price_fee,
         mk_native_token_pair_test_calculation_price_fee, mk_token_pair_test_calculation_price_fee,
-        mock_custom_env, mock_dependencies,
+        mock_custom_env, mock_dependencies, testing_str_to_token_type,
     };
 
     #[test]
@@ -540,8 +540,8 @@ pub mod tests_calculation_price_and_fee {
             mock_env(),
             Uint128::from(100000u32),
             Addr::unchecked("Sender"),
-            true,
-            Some(true),
+            Some(testing_str_to_token_type(CUSTOM_TOKEN_1)),
+            None,
         ).unwrap();
         let withdraw0 = Uint128::from_str(&withdraw_result.attributes.get(3).unwrap().value).unwrap();
         let withdraw1 = Uint128::from_str(&withdraw_result.attributes.get(4).unwrap().value).unwrap();
@@ -554,8 +554,8 @@ pub mod tests_calculation_price_and_fee {
             mock_env(),
             Uint128::from(100000u32),
             Addr::unchecked("Sender"),
-            true,
-            Some(false),
+            Some(testing_str_to_token_type(CUSTOM_TOKEN_2)),
+            None,
         ).unwrap();
         let withdraw0 = Uint128::from_str(&withdraw_result.attributes.get(3).unwrap().value).unwrap();
         let withdraw1 = Uint128::from_str(&withdraw_result.attributes.get(4).unwrap().value).unwrap();
@@ -626,7 +626,7 @@ pub mod tests_calculation_price_and_fee {
             mock_env(),
             balanced_lp_tokens_received,
             Addr::unchecked("Sender"),
-            false,
+            None,
             None,
         ).unwrap();
         let withdraw0 = Uint128::from_str(&withdraw_result.attributes.get(3).unwrap().value).unwrap();
@@ -655,7 +655,7 @@ pub mod tests_calculation_price_and_fee {
             mock_env(),
             sslp_tokens_received,
             Addr::unchecked("Sender"),
-            false,
+            None,
             None,
         ).unwrap();
         let withdraw0 = Uint128::from_str(&withdraw_result.attributes.get(3).unwrap().value).unwrap();
@@ -680,12 +680,24 @@ pub mod tests_calculation_price_and_fee {
         let response = add_result.expect("Unwrap of add liquidity response failed");
         let imbalanced_tokens_received = Uint128::from_str(&response.attributes.get(3).unwrap().value).unwrap();
 
+        //test sslp withdraw slippage limit works
+        let withdraw_expect_err = remove_liquidity(
+            deps.as_mut(),
+            mock_env(),
+            imbalanced_tokens_received,
+            Addr::unchecked("Sender"),
+            Some(testing_str_to_token_type(CUSTOM_TOKEN_1)),
+            Some(Uint128::new(1000000000000000u128)),
+        );
+        assert!(withdraw_expect_err.is_err());
+        assert_eq!(withdraw_expect_err.err().unwrap(), StdError::generic_err("Single sided withdraw returned less than the expected amount"));
+
         let withdraw_result = remove_liquidity(
             deps.as_mut(),
             mock_env(),
             imbalanced_tokens_received,
             Addr::unchecked("Sender"),
-            false,
+            None,
             None,
         ).unwrap();
         let withdraw0 = Uint128::from_str(&withdraw_result.attributes.get(3).unwrap().value).unwrap();
@@ -1222,16 +1234,17 @@ pub mod help_test_lib {
 
     pub fn mk_token_pair_test_calculation_price_fee() -> TokenPair {
         let pair = TokenPair(
-            TokenType::CustomToken {
-                contract_addr: Addr::unchecked(CUSTOM_TOKEN_1.to_string().clone()),
-                token_code_hash: CUSTOM_TOKEN_1.to_string(),
-            },
-            TokenType::CustomToken {
-                contract_addr: Addr::unchecked(CUSTOM_TOKEN_2.to_string().clone()),
-                token_code_hash: CUSTOM_TOKEN_2.to_string(),
-            },
+            testing_str_to_token_type(CUSTOM_TOKEN_1),
+            testing_str_to_token_type(CUSTOM_TOKEN_2),
         );
         pair
+    }
+
+    pub fn testing_str_to_token_type(address: &str) -> TokenType {
+            TokenType::CustomToken {
+                contract_addr: Addr::unchecked(address.to_string().clone()),
+                token_code_hash: address.to_string(),
+            }
     }
 
     pub fn mk_custom_token_amount_test_calculation_price_fee(

--- a/contracts/staking/src/operations.rs
+++ b/contracts/staking/src/operations.rs
@@ -680,6 +680,8 @@ pub fn unstake(
             // SEND LP Token back to Pair Contract With Remove Liquidity
             let remove_liquidity_msg = to_binary(&AmmPairInvokeMsg::RemoveLiquidity {
                 from: Some(caller.clone()),
+                single_sided: false,
+                single_sided_withdraw_in_token0: None,
             })?;
             let msg = snip20::ExecuteMsg::Send {
                 recipient: config.amm_pair.to_string(),

--- a/packages/shadeswap-shared/src/msg.rs
+++ b/packages/shadeswap-shared/src/msg.rs
@@ -194,6 +194,8 @@ pub mod amm_pair {
         },
         RemoveLiquidity {
             from: Option<Addr>,
+            single_sided: bool,
+            single_sided_withdraw_in_token0: Option<bool>,
         },
     }
     #[derive(Serialize, Deserialize, JsonSchema,  Clone, Debug)]

--- a/packages/shadeswap-shared/src/msg.rs
+++ b/packages/shadeswap-shared/src/msg.rs
@@ -194,8 +194,8 @@ pub mod amm_pair {
         },
         RemoveLiquidity {
             from: Option<Addr>,
-            single_sided: bool,
-            single_sided_withdraw_in_token0: Option<bool>,
+            single_sided_withdraw_type: Option<TokenType>, //None means 50/50 balanced withdraw, and a value here tells which token to send the withdraw in
+            single_sided_expected_return: Option<Uint128>, //this field will be ignored on balanced withdraws
         },
     }
     #[derive(Serialize, Deserialize, JsonSchema,  Clone, Debug)]


### PR DESCRIPTION
Adds single sided lp provisions and withdraws by virtually swapping one asset for the other. Slightly changes the remove liquidity message interface