### PR TITLE
Make sslp virtual swap optional

### DIFF
--- a/contracts/amm_pair/src/contract.rs
+++ b/contracts/amm_pair/src/contract.rs
@@ -136,7 +136,8 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
                 deposit,
                 expected_return,
                 staking,
-            } => add_liquidity(deps, env, &info, deposit, expected_return, staking),
+                execute_sslp_virtual_swap,
+            } => add_liquidity(deps, env, &info, deposit, expected_return, staking, execute_sslp_virtual_swap),
             ExecuteMsg::SetCustomPairFee { custom_fee } => {
                 //Don't allow for custom fee with invalid zeros
                 if custom_fee.as_ref().is_some()
@@ -433,8 +434,8 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 query::swap_simulation(deps, env, offer, exclude_fee)
             }
             QueryMsg::GetShadeDaoInfo {} => query::shade_dao_info(deps),
-            QueryMsg::GetEstimatedLiquidity { deposit, sender } => {
-                query::estimated_liquidity(deps, env, &deposit, sender)
+            QueryMsg::GetEstimatedLiquidity { deposit, sender, execute_sslp_virtual_swap } => {
+                query::estimated_liquidity(deps, env, &deposit, sender, execute_sslp_virtual_swap)
             }
             QueryMsg::GetConfig {} => {
                 let config = config_r(deps.storage).load()?;

--- a/contracts/amm_pair/src/operations.rs
+++ b/contracts/amm_pair/src/operations.rs
@@ -637,6 +637,7 @@ pub fn add_liquidity(
     deposit: TokenPairAmount,
     expected_return: Option<Uint128>,
     staking: Option<bool>,
+    execute_sslp_virtual_swap: Option<bool>,
 ) -> StdResult<Response> {
     let config = config_r(deps.storage).load()?;
 
@@ -683,19 +684,24 @@ pub fn add_liquidity(
 
     let pair_contract_pool_liquidity = query::total_supply(deps.as_ref(), &config.lp_token)?;
 
-    let new_deposit = lp_virtual_swap(
-        deps.as_ref(),
-        &env,
-        info.sender.clone(),
-        fee_info.lp_fee,
-        fee_info.shade_dao_fee,
-        fee_info.shade_dao_address,
-        &config,
-        &deposit,
-        pair_contract_pool_liquidity,
-        pool_balances,
-        Some(&mut pair_messages),
-    )?;
+    let new_deposit = 
+        if execute_sslp_virtual_swap.is_some() && execute_sslp_virtual_swap.unwrap() {
+            lp_virtual_swap(
+                deps.as_ref(),
+                &env,
+                info.sender.clone(),
+                fee_info.lp_fee,
+                fee_info.shade_dao_fee,
+                fee_info.shade_dao_address,
+                &config,
+                &deposit,
+                pair_contract_pool_liquidity,
+                pool_balances,
+                Some(&mut pair_messages),
+            )?
+        } else {
+            deposit.clone()
+        };
 
     let lp_tokens = calculate_lp_tokens(&new_deposit, pool_balances, pair_contract_pool_liquidity)?;
 

--- a/contracts/amm_pair/src/test.rs
+++ b/contracts/amm_pair/src/test.rs
@@ -249,7 +249,7 @@ pub mod tests {
         config_w(deps.as_mut().storage).save(&_config)?;
         let amount = Uint128::new(1000u128);
         let result = estimated_liquidity(deps.as_ref(), env, 
-            &mk_token_pair_amount("TOKEN_A", CUSTOM_TOKEN_2,amount, amount), Addr::unchecked("random_address".to_string()));
+            &mk_token_pair_amount("TOKEN_A", CUSTOM_TOKEN_2,amount, amount), Addr::unchecked("random_address".to_string()), None);
         match result.unwrap_err() {
             e =>  assert_eq!(e, StdError::generic_err(
                 "The provided tokens dont match those managed by the contract.",
@@ -679,7 +679,8 @@ pub mod tests_calculation_price_and_fee {
                 amount_1: Uint128::from(10000u128)
             },
             Some(Uint128::from(10000001u128)),
-            None
+            None,
+            None,
         );
 
         assert!(add_liquidity_with_err.is_err());
@@ -737,7 +738,7 @@ pub mod tests_calculation_price_and_fee {
             amount_1: Uint128::from(0u128)
         };
 
-        let estimated_lp_bin = estimated_liquidity(deps.as_ref(), mock_env(), &deposit, Addr::unchecked("random_address".to_string())).unwrap();
+        let estimated_lp_bin = estimated_liquidity(deps.as_ref(), mock_env(), &deposit, Addr::unchecked("random_address".to_string()), Some(true)).unwrap();
         let msg = from_binary::<QueryMsgResponse>(&estimated_lp_bin).unwrap();
         let estimated_lp = match msg {
             QueryMsgResponse::GetEstimatedLiquidity { lp_token, total_lp_token: _ } => lp_token,
@@ -750,7 +751,8 @@ pub mod tests_calculation_price_and_fee {
             &mock_info,
             deposit,
             None,
-            None
+            None,
+            Some(true),
         );
         let response = add_result.expect("Unwrap of add liquidity response failed");
         let lp_tokens_received = Uint128::from_str(&response.attributes.get(3).unwrap().value).unwrap();
@@ -776,7 +778,8 @@ pub mod tests_calculation_price_and_fee {
                 amount_1: Uint128::from(100u128)
             },
             None,
-            None
+            None,
+            None,
         );
         let response = add_result.expect("Unwrap of add liquidity response failed");
         let balanced_lp_tokens_received = Uint128::from_str(&response.attributes.get(3).unwrap().value).unwrap();
@@ -805,7 +808,8 @@ pub mod tests_calculation_price_and_fee {
                 amount_1: Uint128::from(0u128)
             },
             None,
-            None
+            None,
+            Some(true)
         );
         let response = add_result.expect("Unwrap of add liquidity response failed");
         let sslp_tokens_received = Uint128::from_str(&response.attributes.get(3).unwrap().value).unwrap();
@@ -835,7 +839,8 @@ pub mod tests_calculation_price_and_fee {
                 amount_1: Uint128::from(50u128)
             },
             None,
-            None
+            None,
+            Some(true),
         );
         let response = add_result.expect("Unwrap of add liquidity response failed");
         let imbalanced_tokens_received = Uint128::from_str(&response.attributes.get(3).unwrap().value).unwrap();
@@ -888,7 +893,8 @@ pub mod tests_calculation_price_and_fee {
                 amount_1: Uint128::from(10u128)
             },
             None,
-            None
+            None,
+            Some(true),
         );
         let response = add_result.expect("Unwrap of add liquidity response failed");
         let imbalanced_lp_tokens_received = Uint128::from_str(&response.attributes.get(3).unwrap().value).unwrap();
@@ -903,7 +909,8 @@ pub mod tests_calculation_price_and_fee {
                 amount_1: Uint128::from(0u128)
             },
             None,
-            None
+            None,
+            Some(true),
         );
         let response = add_result.expect("Unwrap of add liquidity response failed");
         let sslp_tokens_received = Uint128::from_str(&response.attributes.get(3).unwrap().value).unwrap();
@@ -918,7 +925,8 @@ pub mod tests_calculation_price_and_fee {
                 amount_1: Uint128::from(55u128)
             },
             None,
-            None
+            None,
+            None,
         );
         let response = add_result.expect("Unwrap of add liquidity response failed");
         let balanced_lp_tokens_received = Uint128::from_str(&response.attributes.get(3).unwrap().value).unwrap();
@@ -949,7 +957,8 @@ pub mod tests_calculation_price_and_fee {
                 amount_1: Uint128::from(100000u128)
             },
             Some(Uint128::from(10000000u128)),
-            None
+            None,
+            Some(true),
         )?;       
         Ok(())
     }
@@ -975,7 +984,8 @@ pub mod tests_calculation_price_and_fee {
                 amount_1: Uint128::from(100000u128)
             },
             Some(Uint128::from(9999999u128)),
-            None
+            None,
+            Some(true),
         )?;       
         Ok(())
     }
@@ -997,7 +1007,8 @@ pub mod tests_calculation_price_and_fee {
                 amount_1: Uint128::from(100000u128)
             },
             None,
-            None
+            None,
+            Some(true),
         )?;       
 
         Ok(())

--- a/contracts/amm_pair/tests/integration.rs
+++ b/contracts/amm_pair/tests/integration.rs
@@ -174,7 +174,8 @@ pub fn amm_pair_integration_tests_with_custom_token() {
             amount_1: Uint128::new(100000000u128),
         }, 
         expected_return: Some(Uint128::new(1000u128)), 
-        staking: Some(true) 
+        staking: Some(true),
+        execute_sslp_virtual_swap: None,
     };
  
     let _ = router.execute_contract(
@@ -221,7 +222,8 @@ pub fn amm_pair_integration_tests_with_custom_token() {
             amount_1: Uint128::new(100000000u128),
         }, 
         expected_return: None, 
-        staking: Some(false) 
+        staking: Some(false),
+        execute_sslp_virtual_swap: None,
     };   
  
     let _ = router.execute_contract(
@@ -484,7 +486,8 @@ pub fn amm_pair_integration_tests_native_token() {
             amount_1: Uint128::new(100000000u128),
         }, 
         expected_return: Some(Uint128::new(1000u128)), 
-        staking: Some(true) 
+        staking: Some(true),
+        execute_sslp_virtual_swap: None,
     };
  
     let _ = router.execute_contract(
@@ -531,7 +534,8 @@ pub fn amm_pair_integration_tests_native_token() {
             amount_1: Uint128::new(100000000u128),
         }, 
         expected_return: None, 
-        staking: Some(false) 
+        staking: Some(false),
+        execute_sslp_virtual_swap: None,
     };
  
     let _ = router.execute_contract(
@@ -815,7 +819,8 @@ pub fn test_sslp_with_two_virtual_providers() {
             amount_1: Uint128::new(100000000u128),
         }, 
         expected_return: Some(Uint128::new(100000001u128)), 
-        staking: Some(false) 
+        staking: Some(false),
+        execute_sslp_virtual_swap: None,
     };
     let result = router.execute_contract(
         owner_addr.to_owned(),
@@ -833,7 +838,8 @@ pub fn test_sslp_with_two_virtual_providers() {
             amount_1: Uint128::new(100000000u128),
         }, 
         expected_return: None, 
-        staking: Some(false) 
+        staking: Some(false),
+        execute_sslp_virtual_swap: None,
     };
  
     let _ = router.execute_contract(
@@ -883,7 +889,8 @@ pub fn test_sslp_with_two_virtual_providers() {
             amount_1: Uint128::new(100000000u128),
         }, 
         expected_return: None, 
-        staking: None
+        staking: None,
+        execute_sslp_virtual_swap: Some(true),
     };
  
     let _ = router.execute_contract(
@@ -908,7 +915,8 @@ pub fn test_sslp_with_two_virtual_providers() {
             amount_1: Uint128::zero(),
         }, 
         expected_return: None, 
-        staking: Some(false) 
+        staking: Some(false),
+        execute_sslp_virtual_swap: Some(true),
     };
  
     let _ = router.execute_contract(

--- a/packages/multi_test/src/amm_pairs/amm_pairs_lib.rs
+++ b/packages/multi_test/src/amm_pairs/amm_pairs_lib.rs
@@ -118,7 +118,8 @@ pub mod amm_pairs_lib{
                             amount_1
             ), 
             expected_return: expected_return, 
-            staking: staking 
+            staking: staking,
+            execute_sslp_virtual_swap: None,
         };
 
         let _  = router.execute_contract(

--- a/packages/multi_test/src/amm_pairs/amm_pairs_mock.rs
+++ b/packages/multi_test/src/amm_pairs/amm_pairs_mock.rs
@@ -135,7 +135,7 @@ pub mod amm_pairs_mock {
                     return to_binary(&response);
                 }
                 QueryMsg::GetShadeDaoInfo {} => to_binary(""),
-                QueryMsg::GetEstimatedLiquidity {deposit:_, sender } => to_binary(""),
+                QueryMsg::GetEstimatedLiquidity { .. } => to_binary(""),
             },
             BLOCK_SIZE,
         )
@@ -150,11 +150,7 @@ pub mod amm_pairs_mock {
     ) -> StdResult<Response> {
         pad_response_result(
             match msg {
-                ExecuteMsg::AddLiquidityToAMMContract {
-                    deposit: _,
-                    expected_return: _,
-                    staking: _,
-                } => Ok(Response::new()),
+                ExecuteMsg::AddLiquidityToAMMContract { .. } => Ok(Response::new()),
                 ExecuteMsg::SwapTokens {
                     offer: _,
                     expected_return: _,

--- a/packages/network_integration/src/cli_commands.rs
+++ b/packages/network_integration/src/cli_commands.rs
@@ -1027,6 +1027,7 @@ pub mod amm_pair_lib {
                 },
                 expected_return: expected_return,
                 staking: staking,
+                execute_sslp_virtual_swap: None,
             },
             &pair_contract,
             account_name,

--- a/packages/network_integration/src/launch/deploy.rs
+++ b/packages/network_integration/src/launch/deploy.rs
@@ -609,6 +609,7 @@ fn deploy_fresh() -> serde_json::Result<()> {
                                 expected_return: None,
 
                                 staking: None,
+                                execute_sslp_virtual_swap: None,
                             },
                             &NetContract {
                                 label: "".to_string(),
@@ -683,6 +684,7 @@ fn deploy_fresh() -> serde_json::Result<()> {
                                 },
                                 expected_return: None,
                                 staking: None,
+                                execute_sslp_virtual_swap: None,
                             },
                             &NetContract {
                                 label: "".to_string(),

--- a/packages/network_integration/tests/testnet_integration.rs
+++ b/packages/network_integration/tests/testnet_integration.rs
@@ -403,6 +403,7 @@ fn run_testnet() -> Result<()> {
             },
             expected_return: None,
             staking: None,
+            execute_sslp_virtual_swap: None,
         },
         &NetContract {
             label: "".to_string(),
@@ -1304,6 +1305,7 @@ fn run_testnet() -> Result<()> {
                 },
                 expected_return: None,
                 staking: Some(true),
+                execute_sslp_virtual_swap: None,
             },
             &NetContract {
                 label: "".to_string(),
@@ -1390,6 +1392,7 @@ fn run_testnet() -> Result<()> {
                     },
                     expected_return: None,
                     staking: Some(false),
+                    execute_sslp_virtual_swap: None,
                 },
                 &NetContract {
                     label: "".to_string(),
@@ -1585,6 +1588,7 @@ fn run_testnet() -> Result<()> {
                 amount_1: Uint128::new(10000000000),
             },
             sender: Addr::unchecked(account.clone()),
+            execute_sslp_virtual_swap: None,
         };
         let estimated_lp_token: AMMPairQueryMsgResponse = query(
             &NetContract {
@@ -1714,7 +1718,8 @@ fn run_testnet() -> Result<()> {
                     amount_0: Uint128::from(1000u64),
                     amount_1: Uint128::from(1000u64)
                 },
-                sender: Addr::unchecked(account)
+                sender: Addr::unchecked(account),
+                execute_sslp_virtual_swap: None,
             },
         )?,
         AMMPairQueryMsgResponse::GetEstimatedLiquidity { .. }
@@ -2077,6 +2082,7 @@ fn run_testnet() -> Result<()> {
             },
             expected_return: None,
             staking: Some(true),
+            execute_sslp_virtual_swap: None,
         },
         &NetContract {
             label: "".to_string(),
@@ -2313,6 +2319,7 @@ fn run_testnet() -> Result<()> {
                 },
                 expected_return: None,
                 staking: Some(false),
+                execute_sslp_virtual_swap: None,
             },
             &NetContract {
                 label: "".to_string(),

--- a/packages/shadeswap-shared/src/msg.rs
+++ b/packages/shadeswap-shared/src/msg.rs
@@ -219,6 +219,7 @@ pub mod amm_pair {
             deposit: TokenPairAmount,
             expected_return: Option<Uint128>,
             staking: Option<bool>,
+            execute_sslp_virtual_swap: Option<bool>,
         },
         SwapTokens {
             /// The token type to swap from.
@@ -310,7 +311,8 @@ pub mod amm_pair {
         GetShadeDaoInfo {},
         GetEstimatedLiquidity {
             deposit: TokenPairAmount,
-            sender: Addr
+            sender: Addr,
+            execute_sslp_virtual_swap: Option<bool>,
         },
     }
 


### PR DESCRIPTION
This updates sslp so that the virtual swap is only run when the user sends Some(true) to a new field in the AddLiquidty msg and its matching simulation. This prevents users who provide perfectly balanced liquidity from losing value on potential math imprecision, price impact, and virtual swap fees.